### PR TITLE
chore: only push docker image on master

### DIFF
--- a/.github/workflows/build-beta.yml
+++ b/.github/workflows/build-beta.yml
@@ -1,9 +1,14 @@
-name: Build & Push Astro Beta Image
+name: Build Astro Beta Image
 
 on:
   push:
     branches:
-      - feature/bumbleflies-redesign
+      - master
+      - feature/**
+    paths:
+      - beta/**
+      - .github/workflows/build-beta.yml
+  pull_request:
     paths:
       - beta/**
       - .github/workflows/build-beta.yml
@@ -27,6 +32,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Log in to Container Registry
+        if: github.ref == 'refs/heads/master'
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
@@ -39,13 +45,14 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=beta
+            type=raw,value=beta,enable=${{ github.ref == 'refs/heads/master' }}
+            type=sha,enable=${{ github.ref != 'refs/heads/master' }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v7
         with:
           context: beta
-          push: true
+          push: ${{ github.ref == 'refs/heads/master' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
Improve CI/CD workflow:

- Only build & push image on master branch
- Build only (no push) on feature branches and PRs
- Tag as 'beta' on master, use SHA tag on other branches
- Trigger on all branches and PRs with /beta/** changes