### PR TITLE
feat: identify healthcheck in logs

### DIFF
--- a/beta/Dockerfile
+++ b/beta/Dockerfile
@@ -26,7 +26,7 @@ COPY nginx.conf /etc/nginx/conf.d/default.conf
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD wget --quiet --tries=1 --spider http://localhost/ || exit 1
+  CMD wget --quiet --tries=1 --spider --user-agent="Docker-HealthCheck-AstroBeta" http://localhost/ || exit 1
 
 EXPOSE 80
 


### PR DESCRIPTION
Added a custom User-Agent to the Docker healthcheck wget command. This allows filtering out healthcheck requests from access logs using the identifier 'Docker-HealthCheck-AstroBeta'.