### PR TITLE
ci(astro): track image publishes as GitHub Deployments

### DIFF
--- a/.github/workflows/part_deploy_astro.yml
+++ b/.github/workflows/part_deploy_astro.yml
@@ -18,6 +18,9 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment:
+      name: astro-live
+      url: https://bumbleflies.de
     steps:
       - name: Download image artifact
         uses: actions/download-artifact@v8


### PR DESCRIPTION
## What

Adds an `astro-live` GitHub Environment to the Astro deploy job (`part_deploy_astro.yml`).

## Why

Each `bumblecode/web:www` image publish now registers a tracked **GitHub Deployment** pointing at https://bumbleflies.de, visible in the repo's Environments/Deployments tab with status and URL — matching how the Jekyll pipeline's `deployment-site` environment works.

## Details

- Deployment opens when the deploy job starts (after build + unit tests + image health check pass, on `master`).
- Status is set to success/failure by the job outcome.
- No new secrets, no server-side changes, tracking only (does not pull/restart the image on the server).
- The `astro-live` environment is created automatically on first run; protection rules/approvals can be added later under Settings → Environments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)