### PR TITLE
fix: remove dead links (footer, ServicePillar, ProgramCard) + add dead-link test

### DIFF
--- a/beta/src/components/Footer.astro
+++ b/beta/src/components/Footer.astro
@@ -29,7 +29,7 @@ const year = new Date().getFullYear();
       <h3>{content.services.title}</h3>
       <ul>
         {content.services.items.map((item) => (
-          <li key={item}><a href="#">{item}</a></li>
+          <li key={item.label}><a href={item.href}>{item.label}</a></li>
         ))}
       </ul>
     </div>
@@ -38,7 +38,7 @@ const year = new Date().getFullYear();
       <h3>{content.learn.title}</h3>
       <ul>
         {content.learn.items.map((item) => (
-          <li key={item}><a href="#">{item}</a></li>
+          <li key={item.label}><a href={item.href}>{item.label}</a></li>
         ))}
       </ul>
     </div>

--- a/beta/src/components/ProgramCard.astro
+++ b/beta/src/components/ProgramCard.astro
@@ -7,9 +7,11 @@ interface Props {
   price: string;
   image: string;
   slug: string;
+  lang?: 'DE' | 'EN';
 }
 
-const { name, description, ageGroup, duration, price, image, slug } = Astro.props;
+const { name, description, ageGroup, duration, price, image, slug, lang = 'DE' } = Astro.props;
+const detailHref = lang === 'DE' ? '/services' : '/en/services';
 ---
 
 <article class="bf-program-card">
@@ -39,7 +41,7 @@ const { name, description, ageGroup, duration, price, image, slug } = Astro.prop
 
   <footer class="bf-program-card__footer">
     <div class="bf-program-card__price">{price}</div>
-    <a href={`/programs/${slug}`} class="bf-cta">Mehr Infos</a>
+    <a href={detailHref} class="bf-cta">Mehr Infos</a>
   </footer>
 </article>
 

--- a/beta/src/components/ServicePillar.astro
+++ b/beta/src/components/ServicePillar.astro
@@ -16,6 +16,7 @@ interface Props {
 
 const { number, title, tag, description, bullets, formats, learnMoreLabel, lang = 'DE' } = Astro.props;
 const label = learnMoreLabel || (lang === 'DE' ? 'Mehr erfahren →' : 'Learn more →');
+const learnMoreHref = lang === 'DE' ? '/services' : '/en/services';
 ---
 
 <article class="a-service">
@@ -38,7 +39,7 @@ const label = learnMoreLabel || (lang === 'DE' ? 'Mehr erfahren →' : 'Learn mo
     ))}
   </ul>
 
-  <a href="#" class="a-service__link">{label}</a>
+  <a href={learnMoreHref} class="a-service__link">{label}</a>
 </article>
 
 <style>

--- a/beta/src/lib/footerContent.ts
+++ b/beta/src/lib/footerContent.ts
@@ -7,10 +7,15 @@ export interface ContactItem {
 
 export interface FooterContent {
   about: string;
-  services: { title: string; items: string[] };
-  learn: { title: string; items: string[] };
+  services: { title: string; items: LinkItem[] };
+  learn: { title: string; items: LinkItem[] };
   contact: { title: string; items: ContactItem[] };
   legal: string[];
+}
+
+interface LinkItem {
+  label: string;
+  href: string;
 }
 
 const contactItems: ContactItem[] = [
@@ -21,20 +26,53 @@ const contactItems: ContactItem[] = [
 ];
 
 export function getFooterContent(lang: Lang): FooterContent {
+  const servicesHref = lang === 'DE' ? '/services' : '/en/services';
   return lang === 'DE'
     ? {
         about:
           'Eine kleine Werkstatt aus Facilitator:innen, KI-Consultants und Entwickler:innen. Remote-first, vor Ort wenn\'s zählt.',
-        services: { title: 'Leistungen', items: ['Facilitation (remote, hybrid, vor Ort)', 'AI Consulting', 'App Development', 'Coaching & Handover'] },
-        learn: { title: 'Lernen', items: ['FaST-Training', 'GPT-Training', 'AI-Literacy', 'Open Space Checkliste'] },
+        services: {
+          title: 'Leistungen',
+          items: [
+            { label: 'Facilitation (remote, hybrid, vor Ort)', href: servicesHref },
+            { label: 'AI Consulting', href: servicesHref },
+            { label: 'App Development', href: servicesHref },
+            { label: 'Coaching & Handover', href: servicesHref },
+          ],
+        },
+        learn: {
+          title: 'Lernen',
+          items: [
+            { label: 'FaST-Training', href: servicesHref },
+            { label: 'GPT-Training', href: servicesHref },
+            { label: 'AI-Literacy', href: servicesHref },
+            { label: 'Open Space Checkliste', href: servicesHref },
+          ],
+        },
         contact: { title: 'Kontakt', items: contactItems },
         legal: ['Impressum', 'Datenschutz'],
       }
     : {
         about:
           'A small workshop of facilitators, AI consultants and developers. Remote-first, on-site when it matters.',
-        services: { title: 'Services', items: ['Facilitation (remote, hybrid, on-site)', 'AI Consulting', 'App Development', 'Coaching & Handover'] },
-        learn: { title: 'Learn', items: ['FaST Training', 'GPT Training', 'AI Literacy', 'Open Space Checklist'] },
+        services: {
+          title: 'Services',
+          items: [
+            { label: 'Facilitation (remote, hybrid, on-site)', href: servicesHref },
+            { label: 'AI Consulting', href: servicesHref },
+            { label: 'App Development', href: servicesHref },
+            { label: 'Coaching & Handover', href: servicesHref },
+          ],
+        },
+        learn: {
+          title: 'Learn',
+          items: [
+            { label: 'FaST Training', href: servicesHref },
+            { label: 'GPT Training', href: servicesHref },
+            { label: 'AI Literacy', href: servicesHref },
+            { label: 'Open Space Checklist', href: servicesHref },
+          ],
+        },
         contact: { title: 'Contact', items: contactItems },
         legal: ['Imprint', 'Privacy'],
       };

--- a/beta/tests/dead-links.test.ts
+++ b/beta/tests/dead-links.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest';
+import { promises as fs } from 'fs';
+import { join } from 'path';
+
+const SRC_DIR = join(process.cwd(), 'src');
+const PAGES_DIR = join(SRC_DIR, 'pages');
+const PUBLIC_DIR = join(process.cwd(), 'public');
+
+// Hrefs that never point to an internal route and should not be flagged.
+const EXTERNAL_OR_SPECIAL = /^(mailto:|tel:|https?:\/\/|#)/;
+
+// Recursively list files with a given extension under a directory.
+async function listFiles(dir: string, ext: string): Promise<string[]> {
+  const out: string[] = [];
+  async function walk(d: string) {
+    let entries: import('fs').Dirent[];
+    try {
+      entries = await fs.readdir(d, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = join(d, entry.name);
+      if (entry.isDirectory()) {
+        await walk(full);
+      } else if (entry.name.endsWith(ext)) {
+        out.push(full);
+      }
+    }
+  }
+  await walk(dir);
+  return out;
+}
+
+// Resolve an internal path (e.g. "/services", "/en/", "/case-studies/foo")
+// to the source file that would serve it, and report whether it exists.
+async function routeExists(path: string): Promise<boolean> {
+  if (EXTERNAL_OR_SPECIAL.test(path)) return true;
+
+  const parts = path.split('/').filter(Boolean);
+
+  let file: string;
+  if (parts.length === 0) {
+    file = 'index.astro'; // "/"
+  } else if (path.endsWith('/')) {
+    file = `${parts.join('/')}/index.astro`; // "/en/"
+  } else {
+    file = `${parts.join('/')}.astro`;
+  }
+
+  try {
+    await fs.access(join(PAGES_DIR, file));
+    return true;
+  } catch {
+    // Static assets live in public/ (e.g. /favicon.ico, /images/...).
+    try {
+      await fs.access(join(PUBLIC_DIR, path.replace(/^\/+/, '')));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+// Collect every href literal found in a source file.
+// Returns the literal path strings that should be validated as internal links.
+function extractHrefs(content: string): string[] {
+  const hrefs: string[] = [];
+
+  // 1. Static quoted hrefs: href="/services" or href="#"
+  const quoted = /href=(["'])([^"']*)\1/g;
+  let m: RegExpExecArray | null;
+  while ((m = quoted.exec(content)) !== null) {
+    hrefs.push(m[2]);
+  }
+
+  // 2. Expression hrefs: href={...} (may wrap a backtick template or a variable)
+  const expression = /href=\{([^}]*)\}/g;
+  while ((m = expression.exec(content)) !== null) {
+    hrefs.push(...parseExpression(m[1]));
+  }
+
+  return hrefs;
+}
+
+// Pull candidate internal paths out of an Astro/TS expression.
+function parseExpression(expr: string): string[] {
+  const candidates: string[] = [];
+
+  // Quoted string literals inside the expression.
+  const quotedLit = /['"]([^'"]*)['"]/g;
+  let q: RegExpExecArray | null;
+  while ((q = quotedLit.exec(expr)) !== null) {
+    candidates.push(q[1]);
+  }
+
+  // Unquoted path literals, e.g. the `/programs/` left after stripping ${...}
+  // and backticks: href={`/programs/${slug}`} -> /programs/
+  let unquoted = expr.replace(/`/g, '').replace(/\$\{[^}]*\}/g, '');
+  const pathLike = unquoted.match(/\/[A-Za-z0-9/_-]+/g);
+  if (pathLike) candidates.push(...pathLike);
+
+  return candidates;
+}
+
+describe('Dead link detection', () => {
+  it('should not contain any placeholder (href="#") links', async () => {
+    const files = await listFiles(SRC_DIR, '.astro');
+    const dead: string[] = [];
+
+    for (const file of files) {
+      const content = await fs.readFile(file, 'utf8');
+      if (content.includes('href="#"')) {
+        dead.push(file.replace(SRC_DIR, 'src'));
+      }
+    }
+
+    expect(dead).toEqual([], `Placeholder links (href="#") found in: ${dead.join(', ')}`);
+  });
+
+  it('should have no internal links pointing to non-existent routes', async () => {
+    const files = [...(await listFiles(SRC_DIR, '.astro')), ...(await listFiles(SRC_DIR, '.ts'))];
+    const dead: string[] = [];
+
+    for (const file of files) {
+      const content = await fs.readFile(file, 'utf8');
+      const hrefs = extractHrefs(content);
+
+      for (const href of hrefs) {
+        // Normalize: strip trailing slash for route resolution, keep "/" as-is.
+        const normalized = href === '/' ? '/' : href.replace(/\/+$/, '');
+        if (!normalized.startsWith('/')) continue; // skip external/special/relative
+        if (normalized === '#') {
+          dead.push(`${file.replace(SRC_DIR, 'src')}: "${href}"`);
+          continue;
+        }
+        const exists = await routeExists(normalized);
+        if (!exists) {
+          dead.push(`${file.replace(SRC_DIR, 'src')}: "${href}"`);
+        }
+      }
+    }
+
+    expect(dead).toEqual([], `Dead internal links found:\n${dead.join('\n')}`);
+  });
+});


### PR DESCRIPTION
## Summary
Removes all dead links in the Astro site (`beta/`) and adds a static test that guards against regressions.

### Dead links found & fixed
- **Footer.astro** — services & learn columns used `href="#"` placeholders (rendered on every page) -> now point to the services page (`/services` / `/en/services`).
- **ServicePillar.astro** — Learn more link used `href="#"` -> now links to the language-appropriate services page.
- **ProgramCard.astro** — linked to `/programs/:slug`, a route that does not exist -> now links to the services page (added `lang` prop).

### Test
- Adds `beta/tests/dead-links.test.ts`, which statically scans every `src/**` href and fails on placeholder (`#`) links or internal paths that do not resolve to a `src/pages` route or a `public/` asset.

### Verification
- `npm run build` succeeds (25 pages); no `href="#"` remains in `dist/`.
- New dead-link test + Footer/Nav/Hero unit tests pass (13/13).