### PR TITLE
fix(ai-consulting): render intro, tighten layout & strengthen linking

### DIFF
--- a/beta/src/components/ServiceCard.astro
+++ b/beta/src/components/ServiceCard.astro
@@ -6,9 +6,10 @@ interface Props {
   description: string;
   bullets: string[];
   href?: string;
+  ctaLabel?: string;
 }
 
-const { number, title, tag, description, bullets, href } = Astro.props;
+const { number, title, tag, description, bullets, href, ctaLabel } = Astro.props;
 const attrs = Astro.props;
 ---
 
@@ -28,6 +29,12 @@ const attrs = Astro.props;
       <li>{bullet}</li>
     ))}
   </ul>
+
+  {href && ctaLabel && (
+    <span class="a-service-card__cta">
+      {ctaLabel}<span class="a-service-card__cta-arrow" aria-hidden="true">↗</span>
+    </span>
+  )}
 </article>
 
 <style>
@@ -134,6 +141,26 @@ const attrs = Astro.props;
     left: 0;
     color: var(--accent);
     font-weight: 600;
+  }
+
+  .a-service-card__cta {
+    margin-top: auto;
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    text-transform: uppercase;
+    letter-spacing: var(--ls-wide);
+    color: var(--accent);
+    display: inline-flex;
+    align-items: center;
+  }
+
+  .a-service-card__cta-arrow {
+    margin-left: 0.4em;
+    transition: transform var(--duration-normal);
+  }
+
+  .a-service-card:hover .a-service-card__cta-arrow {
+    transform: translate(2px, -2px);
   }
 
   @media (max-width: 768px) {

--- a/beta/src/components/StationFlow.astro
+++ b/beta/src/components/StationFlow.astro
@@ -36,7 +36,11 @@ const { eyebrow, heading, stations, lang = 'DE' } = Astro.props;
               {station.href ? <a href={station.href} class="a-flow-subtitle-link">{station.subtitle}</a> : station.subtitle}
             </span>
             <h3 class="a-flow-title">
-              {station.href ? <a href={station.href} class="a-flow-title-link">{station.title}</a> : station.title}
+              {station.href ? (
+                <a href={station.href} class="a-flow-title-link">
+                  {station.title}<span class="a-flow-title-arrow" aria-hidden="true">↗</span>
+                </a>
+              ) : station.title}
             </h3>
           </div>
           <div class="a-flow-desc">
@@ -173,6 +177,19 @@ const { eyebrow, heading, stations, lang = 'DE' } = Astro.props;
   .a-flow-subtitle-link:hover,
   .a-flow-title-link:hover {
     color: var(--accent);
+  }
+
+  .a-flow-title-arrow {
+    display: inline-block;
+    margin-left: 0.2em;
+    font-size: 0.6em;
+    vertical-align: 0.35em;
+    color: var(--accent);
+    transition: transform var(--duration-fast);
+  }
+
+  .a-flow-title-link:hover .a-flow-title-arrow {
+    transform: translate(2px, -2px);
   }
 
   @media (max-width: 768px) {

--- a/beta/src/content/pages/ai-consulting.nt
+++ b/beta/src/content/pages/ai-consulting.nt
@@ -1,10 +1,7 @@
 title: AI Consulting — From Conversation to Code
 published: true
 heading: KI-Beratung, die liefert.
-subheading: Vom ersten Gespräch zur laufenden KI-Lösung. Wir helfen dir, KI nicht nur zu verstehen, sondern einzusetzen.
-intro: |
-  Die meisten KI-Beratungen enden mit einer PowerPoint. Wir enden mit funktionierender Software.
-  Unser Versprechen: From Conversation to Code. Du erzählst uns dein Problem. Wir entwickeln die Strategie. Und dann bauen wir.
+subheading: Vom ersten Gespräch zur laufenden KI-Lösung. Andere liefern eine PowerPoint — wir liefern funktionierende Software.
 steps:
   - number: "01"
     title: Verstehen

--- a/beta/src/content/pages/en/ai-consulting.nt
+++ b/beta/src/content/pages/en/ai-consulting.nt
@@ -1,10 +1,7 @@
 title: AI Consulting — From Conversation to Code
 published: true
 heading: AI consulting that delivers.
-subheading: From the first conversation to a working AI solution. We help you not just understand AI, but deploy it.
-intro: |
-  Most AI consulting ends with a PowerPoint deck. We end with working software.
-  Our promise: From Conversation to Code. You tell us your problem. We develop the strategy. And then we build.
+subheading: From the first conversation to a running AI solution. Others hand you a slide deck — we hand you working software.
 steps:
   - number: "01"
     title: Understand

--- a/beta/src/pages/ai-consulting.astro
+++ b/beta/src/pages/ai-consulting.astro
@@ -46,14 +46,6 @@ let lang: 'DE' | 'EN' = 'DE';
     </div>
   </section>
 
-  <section class="a-ai-intro bf-section">
-    <div class="bf-container">
-      <p class="a-ai-intro__text" data-de={deContent.intro} data-en={enContent.intro}>
-        {deContent.intro}
-      </p>
-    </div>
-  </section>
-
   <section class="a-ai-steps bf-section">
     <div class="bf-container">
       <h2 class="a-ai-steps__heading" data-de="Unser Weg: Conversation to Code" data-en="Our path: Conversation to Code">
@@ -159,20 +151,9 @@ let lang: 'DE' | 'EN' = 'DE';
     max-width: 650px;
     margin: 0;
   }
-  .a-ai-intro {
-    padding: 0 0 4rem;
-  }
-  .a-ai-intro__text {
-    font-size: 1.15rem;
-    line-height: 1.6;
-    color: var(--ink);
-    max-width: 700px;
-    margin: 0;
-    white-space: pre-line;
-  }
   .a-ai-steps {
     padding: 4rem 0;
-    background: var(--paper);
+    background: var(--bg);
   }
   .a-ai-steps__heading {
     font-family: var(--font-display);
@@ -211,6 +192,7 @@ let lang: 'DE' | 'EN' = 'DE';
   }
   .a-ai-services {
     padding: 4rem 0;
+    background: var(--paper);
   }
   .a-ai-services__heading {
     font-family: var(--font-display);
@@ -242,14 +224,13 @@ let lang: 'DE' | 'EN' = 'DE';
   }
   .a-ai-quote {
     padding: 4rem 0;
-    background: var(--paper);
+    background: var(--bg);
     text-align: center;
   }
   @media (max-width: 768px) {
     .a-ai-hero { padding: 2.5rem 0; }
     .a-ai-hero__heading { font-size: 2rem; }
     .a-ai-hero__subheading { font-size: 1rem; }
-    .a-ai-intro { padding: 0 0 2.5rem; }
     .a-ai-steps { padding: 2.5rem 0; }
     .a-ai-steps__heading { font-size: 1.5rem; }
     .a-ai-steps__grid { grid-template-columns: 1fr; gap: 1.5rem; }

--- a/beta/src/pages/en/ai-consulting.astro
+++ b/beta/src/pages/en/ai-consulting.astro
@@ -37,12 +37,6 @@ const lang: 'DE' | 'EN' = 'EN';
     </div>
   </section>
 
-  <section class="a-ai-intro bf-section">
-    <div class="bf-container">
-      <p class="a-ai-intro__text">{content.intro}</p>
-    </div>
-  </section>
-
   <section class="a-ai-steps bf-section">
     <div class="bf-container">
       <h2 class="a-ai-steps__heading">Our path: Conversation to Code</h2>
@@ -131,20 +125,9 @@ const lang: 'DE' | 'EN' = 'EN';
     max-width: 650px;
     margin: 0;
   }
-  .a-ai-intro {
-    padding: 0 0 4rem;
-  }
-  .a-ai-intro__text {
-    font-size: 1.15rem;
-    line-height: 1.6;
-    color: var(--ink);
-    max-width: 700px;
-    margin: 0;
-    white-space: pre-line;
-  }
   .a-ai-steps {
     padding: 4rem 0;
-    background: var(--paper);
+    background: var(--bg);
   }
   .a-ai-steps__heading {
     font-family: var(--font-display);
@@ -183,6 +166,7 @@ const lang: 'DE' | 'EN' = 'EN';
   }
   .a-ai-services {
     padding: 4rem 0;
+    background: var(--paper);
   }
   .a-ai-services__heading {
     font-family: var(--font-display);
@@ -214,14 +198,13 @@ const lang: 'DE' | 'EN' = 'EN';
   }
   .a-ai-quote {
     padding: 4rem 0;
-    background: var(--paper);
+    background: var(--bg);
     text-align: center;
   }
   @media (max-width: 768px) {
     .a-ai-hero { padding: 2.5rem 0; }
     .a-ai-hero__heading { font-size: 2rem; }
     .a-ai-hero__subheading { font-size: 1rem; }
-    .a-ai-intro { padding: 0 0 2.5rem; }
     .a-ai-steps { padding: 2.5rem 0; }
     .a-ai-steps__heading { font-size: 1.5rem; }
     .a-ai-steps__grid { grid-template-columns: 1fr; gap: 1.5rem; }

--- a/beta/src/pages/en/services.astro
+++ b/beta/src/pages/en/services.astro
@@ -120,6 +120,7 @@ const lang: 'DE' | 'EN' = 'EN';
               description={service.description}
               bullets={service.bullets}
               href={service.number === '02' ? '/en/ai-consulting' : undefined}
+              ctaLabel="Learn more"
             />
           ))}
         </div>

--- a/beta/src/pages/services.astro
+++ b/beta/src/pages/services.astro
@@ -190,6 +190,7 @@ const enContent = content.EN;
               description={service.description}
               bullets={service.bullets}
               href={service.number === '02' ? '/ai-consulting' : undefined}
+              ctaLabel="Mehr erfahren"
               data-service-id={index}
             />
           ))}

--- a/docs/superpowers/specs/2026-07-09-ai-consulting-page-polish-design.md
+++ b/docs/superpowers/specs/2026-07-09-ai-consulting-page-polish-design.md
@@ -1,0 +1,80 @@
+# AI Consulting Page — Fix, Polish & Linking
+
+**Date:** 2026-07-09
+**Status:** Approved
+**Context:** Follow-up to PR #94 (SEO overhaul + AI consulting page). The live page at
+`/ai-consulting` renders a broken intro section (a lone `|`), feels thin/redundant against
+the closing quote, and is under-emphasised in the site's internal linking.
+
+## Problem
+
+1. **Broken intro (`|`).** `beta/src/content/pages/ai-consulting.nt` writes `intro:` as a
+   YAML-style block scalar (`intro: |` + indented lines). The site's custom NestedText parser
+   (`beta/lib/nestedtext.ts`) has **no `|` block-scalar support** — it reads the value as the
+   literal string `|` and drops the indented lines. The `pages` collection loads only `.nt`
+   files, so the correct-but-unused `.md` twin never renders. Same bug in `en/ai-consulting.nt`.
+2. **"Looks smaller / strange."** The intro is its own `<section>` on `--bg`, wedged between
+   two `--paper` sections. Even with content it reads as an afterthought; empty, it looks like
+   dead space. The page is also the only one with a standalone intro band and uses hardcoded
+   `rem` values instead of the site's design tokens.
+3. **Redundancy.** The intro and the closing manifesto quote both open with "Die meisten…" and
+   make the same conversation-to-code point.
+4. **Weak linking.** The homepage StationFlow station 02 and the services-page card both link
+   to `/ai-consulting`, but only via hover — no persistent affordance signals they're clickable.
+
+## Decision
+
+Scope (user-approved): **fix + polish + linking**. Fix the bug at the **content level** (not
+by hardening the parser). Keep copy genuine and match the site-wide structure.
+
+### A. Structure — match the site-wide hero pattern
+- **Remove** the standalone `.a-ai-intro` section from `ai-consulting.astro` and
+  `en/ai-consulting.astro`. No other page has a lone intro band.
+- Hero becomes **eyebrow + heading + one intro paragraph** on `--paper`, mirroring
+  `how-we-work.astro`. The intro paragraph replaces the thinner subheading.
+- Restore clean `--paper` / `--bg` alternation across the remaining sections
+  (hero → steps → services → quote) so none look collapsed.
+- Replace the page's hardcoded `3rem` / `4rem` / `1.25rem` values with the site's
+  `--space-*` / `--text-*` design tokens.
+
+### B. Copy — genuine, distinct from the quote
+Two-sentence hero intro (matches the terse editorial voice; drops the "Die meisten…" echo):
+
+- **DE:** „Vom ersten Gespräch zur laufenden KI-Lösung. Andere liefern eine PowerPoint — wir
+  liefern funktionierende Software."
+- **EN:** "From the first conversation to a running AI solution. Others hand you a slide deck —
+  we hand you working software."
+
+The manifesto quote strip stays as the closing flourish.
+
+**Field mapping:** the new copy lives in the `.nt` `subheading` field as a **single inline
+line** (no `|` block scalar). The hero renders `subheading` as its intro paragraph. The
+`intro:` field and the `.a-ai-intro` section are removed entirely. The `.nt` files must
+contain no `|` block scalars.
+
+### C. Linking — persistent affordance, using the site's own arrow vocabulary
+The site already assigns meaning to its arrows: `→` (horizontal) is for **list bullets**;
+`↗` (diagonal) is the **navigation / "go somewhere"** mark (nav CTA "Schreib uns ↗",
+`CTAStrip` button). Therefore use **`↗`**:
+- **`StationFlow.astro`:** append a persistent `↗` to a station's linked title (only when
+  `href` is set), so homepage station 02 reads as clickable without hovering.
+- **`ServiceCard.astro`:** when `href` is set, add a persistent "Mehr erfahren ↗" /
+  "Learn more ↗" cue at the card foot. The whole card already links via an overlay anchor;
+  this only makes the affordance visible.
+
+## Files touched
+- `beta/src/content/pages/ai-consulting.nt` — fix intro, remove block scalar
+- `beta/src/content/pages/en/ai-consulting.nt` — same (EN)
+- `beta/src/pages/ai-consulting.astro` — fold intro into hero, drop standalone section, tokens, bg alternation
+- `beta/src/pages/en/ai-consulting.astro` — same (EN)
+- `beta/src/components/StationFlow.astro` — `↗` on linked titles
+- `beta/src/components/ServiceCard.astro` — "Mehr erfahren ↗" / "Learn more ↗" when `href` set
+
+## Out of scope
+- Hardening the NestedText parser to support `|` block scalars (deliberately deferred).
+- Removing the unused `.md` page twins (pre-existing site-wide pattern, not this page's problem).
+
+## Verification
+- `astro check` (types), `npm run test` (Vitest — includes `Nav.test.ts`), `npm run build`.
+- Visual check of `/ai-consulting` and `/en/ai-consulting`: no `|`, full hero, clean
+  alternation; homepage station 02 and services card 02 show a visible `↗`.

--- a/docs/superpowers/specs/2026-07-09-ai-consulting-page-polish-design.md
+++ b/docs/superpowers/specs/2026-07-09-ai-consulting-page-polish-design.md
@@ -33,9 +33,10 @@ by hardening the parser). Keep copy genuine and match the site-wide structure.
 - Hero becomes **eyebrow + heading + one intro paragraph** on `--paper`, mirroring
   `how-we-work.astro`. The intro paragraph replaces the thinner subheading.
 - Restore clean `--paper` / `--bg` alternation across the remaining sections
-  (hero → steps → services → quote) so none look collapsed.
-- Replace the page's hardcoded `3rem` / `4rem` / `1.25rem` values with the site's
-  `--space-*` / `--text-*` design tokens.
+  (hero `paper` → steps `bg` → services `paper` → quote `bg`) so none look collapsed.
+- **Keep** the hero's hardcoded `4rem` / `3rem` / `1.25rem` values: the sibling
+  `how-we-work.astro` uses the identical hardcoded values in its scoped styles, so these
+  already match the site. Converting to tokens would make the page *less* consistent, not more.
 
 ### B. Copy — genuine, distinct from the quote
 Two-sentence hero intro (matches the terse editorial voice; drops the "Die meisten…" echo):


### PR DESCRIPTION
Follow-up to #94. Reviews and fixes the new `/ai-consulting` page.

## Problem
The live page rendered a lone `|` where the intro should be. Root cause: `ai-consulting.nt` wrote the intro as a YAML-style block scalar (`intro: |`), but the `pages` collection uses a **custom NestedText parser** (`beta/lib/nestedtext.ts`) with **no `|` block-scalar support** — it read the value as the literal `|` and dropped the indented lines. The empty band made the page look thin, and the (broken) intro also echoed the closing manifesto quote.

## Changes
- **Fix:** intro copy moves into the hero as a single inline `subheading` line (DE + EN) — no more `|`.
- **Copy:** reworded so it no longer echoes the quote (“…Andere liefern eine PowerPoint — wir liefern funktionierende Software.” / “…Others hand you a slide deck — we hand you working software.”). Manifesto quote stays as the closer.
- **Layout:** removed the standalone `.a-ai-intro` section (no other page has one) and restored clean `--paper`/`--bg` alternation (hero → steps → services → quote). Hero sizes kept as-is — they already match the sibling `how-we-work.astro`.
- **Linking:** persistent `↗` affordance on linked `StationFlow` titles (homepage station 02) and on linked `ServiceCard`s (new `ctaLabel` prop → “Mehr erfahren ↗” / “Learn more ↗”). `↗` matches the site’s nav-arrow convention; `→` stays reserved for list bullets.

## Verification
- `npm run build` ✓ (27 pages).
- Rendered + screenshotted `/ai-consulting`, `/en/ai-consulting`, `/services`: `|` gone, hero full, sections alternate, both `↗` affordances render.

Design spec: `docs/superpowers/specs/2026-07-09-ai-consulting-page-polish-design.md`.

## Out of scope
- Hardening the NestedText parser to support `|` block scalars (deliberately deferred).
- Removing the unused `.md` page twins (pre-existing site-wide pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)