### PR TITLE
fix(seo): trailing-slash canonicals, CTA heading spacing, description copy

### DIFF
--- a/beta/src/components/CTAStrip.astro
+++ b/beta/src/components/CTAStrip.astro
@@ -15,7 +15,7 @@ const { heading, headingEm, body, ctaText, ctaHref = 'mailto:info@bumbleflies.de
   <div class="bf-container" style="text-align: center;">
     <h2 style="font-family: var(--font-display); font-size: var(--text-5xl); letter-spacing: -0.03em; line-height: 1; margin: 0 auto 32px; max-width: 800px;">
       {heading}
-      {headingEm && <em style="font-style: italic; color: var(--accent);">{headingEm}</em>}
+      {headingEm && <> <em style="font-style: italic; color: var(--accent);">{headingEm}</em></>}
     </h2>
     <p style="font-size: var(--text-base); line-height: var(--lh-generous); color: var(--ink-soft); max-width: 700px; margin: 0 auto 32px;">
       {body}

--- a/beta/src/components/Layout.astro
+++ b/beta/src/components/Layout.astro
@@ -28,9 +28,28 @@ const {
 } = Astro.props;
 
 const htmlLang = lang === 'DE' ? 'de' : 'en';
-const fullCanonical = canonical || `${SITE_URL}${dePath || ''}`;
-const deUrl = dePath ? `${SITE_URL}${dePath}` : undefined;
-const enUrl = enPath ? `${SITE_URL}${enPath}` : undefined;
+
+// The site is built with Astro's default directory format (trailing slash) and
+// the sitemap lists trailing-slash URLs. Normalise canonical/og:url/hreflang to
+// match the served URL so they don't point at a redirecting (301) address.
+function withTrailingSlash(url: string | undefined): string | undefined {
+  if (!url) return url;
+  try {
+    const u = new URL(url);
+    if (u.search || u.hash) return url; // leave query/hash URLs untouched
+    if (u.pathname === '' || u.pathname === '/') return `${u.origin}/`;
+    const lastSegment = u.pathname.split('/').pop() ?? '';
+    if (lastSegment.includes('.')) return url; // leave file URLs untouched
+    if (!u.pathname.endsWith('/')) u.pathname += '/';
+    return u.toString();
+  } catch {
+    return url;
+  }
+}
+
+const fullCanonical = withTrailingSlash(canonical || `${SITE_URL}${dePath || ''}`);
+const deUrl = withTrailingSlash(dePath ? `${SITE_URL}${dePath}` : undefined);
+const enUrl = withTrailingSlash(enPath ? `${SITE_URL}${enPath}` : undefined);
 const ogImageUrl = ogImage.startsWith('http') ? ogImage : `${SITE_URL}${ogImage}`;
 
 const jsonLd = JSON.stringify({

--- a/beta/src/pages/ai-consulting.astro
+++ b/beta/src/pages/ai-consulting.astro
@@ -24,7 +24,7 @@ let lang: 'DE' | 'EN' = 'DE';
 
 <Layout
   title={deContent.title}
-  description="Von der ersten Idee zur laufenden KI-Lösung. Wir helfen dir, KI nicht nur zu verstehen, sondern einzusetzen — Conversation to Code in Tagen, nicht Monaten."
+  description="Vom ersten Gespräch zur laufenden KI-Lösung. Wir helfen dir, KI nicht nur zu verstehen, sondern einzusetzen — Conversation to Code in Tagen, nicht Monaten."
   canonical="https://bumbleflies.de/ai-consulting"
   lang={lang}
   dePath="/ai-consulting"

--- a/beta/src/pages/en/ai-consulting.astro
+++ b/beta/src/pages/en/ai-consulting.astro
@@ -19,7 +19,7 @@ const lang: 'DE' | 'EN' = 'EN';
 
 <Layout
   title={content.title}
-  description="From the first conversation to a working AI solution. We help you not just understand AI, but deploy it — Conversation to Code in days, not months."
+  description="From the first conversation to a running AI solution. We help you not just understand AI, but deploy it — Conversation to Code in days, not months."
   canonical="https://bumbleflies.de/en/ai-consulting"
   lang={lang}
   dePath="/ai-consulting"


### PR DESCRIPTION
Follow-up to the `/ai-consulting` review — fixes SEO/text issues found on the **live** page. All three are site-wide (inherited from #94), so the fixes benefit every page.

## Fixes
1. **Trailing-slash canonicals (SEO).** `canonical`, `og:url` and `hreflang` pointed at non-slash URLs (e.g. `https://bumbleflies.de/ai-consulting`) that **301-redirect** to the served `…/ai-consulting/`, and disagreed with the trailing-slash URLs in `sitemap-0.xml`. Added a `withTrailingSlash()` normaliser in `Layout.astro` so all self-referential URLs match the served form (root canonical is now `https://bumbleflies.de/`). File URLs and query/hash URLs are left untouched.
2. **CTA heading spacing (text).** `CTAStrip` rendered `{heading}` and its emphasised tail with no space between them — `Lass uns<em>reden.</em>` → "Lass unsreden.". Added an explicit space; now "Lass uns reden." / "Was steht bei euch als nächstes an?".
3. **Description copy.** Aligned the AI-consulting meta descriptions with the hero (DE "Idee" → "Gespräch"; EN "working" → "running").

## Verification
- `npm run build` ✓ (27 pages); unit tests ✓ (24/24, integration suite needs a live dev server, unrelated).
- Confirmed in built HTML: `/ai-consulting/`, homepage, and case-study canonicals/hreflang all carry the trailing slash; both CTA headings now have the space.

## Noted, not fixed here (separate pre-existing bug)
The `impressum` page sets no `dePath`/`canonical`, so its canonical defaults to the site root (`https://bumbleflies.de/`) instead of `…/impressum/`. Out of scope for this PR — happy to fix in a follow-up.

## Next
The `og:image` is still an SVG (issue 2), which social platforms don't render — that's the next PR, pending a real 1200×630 PNG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)