### PR TITLE
fix(seo): give legal pages self-referential canonicals

### DIFF
--- a/beta/src/pages/datenschutz.astro
+++ b/beta/src/pages/datenschutz.astro
@@ -4,7 +4,12 @@ import Nav from '../components/Nav.astro';
 import Footer from '../components/Footer.astro';
 ---
 
-<Layout title="Datenschutz">
+<Layout
+  title="Datenschutz"
+  canonical="https://bumbleflies.de/datenschutz"
+  dePath="/datenschutz"
+  enPath="/en/privacy"
+>
   <Nav slot="nav" lang="DE" />
   <Footer slot="footer" lang="DE" />
   <div style="max-width: 800px; margin: 4rem auto; padding: 0 2rem; line-height: 1.8;">

--- a/beta/src/pages/en/imprint.astro
+++ b/beta/src/pages/en/imprint.astro
@@ -4,7 +4,13 @@ import Nav from '../../components/Nav.astro';
 import Footer from '../../components/Footer.astro';
 ---
 
-<Layout title="Imprint" lang="EN">
+<Layout
+  title="Imprint"
+  lang="EN"
+  canonical="https://bumbleflies.de/en/imprint"
+  dePath="/impressum"
+  enPath="/en/imprint"
+>
   <Nav slot="nav" lang="EN" />
   <Footer slot="footer" lang="EN" />
   <div style="max-width: 800px; margin: 4rem auto; padding: 0 2rem; line-height: 1.8;">

--- a/beta/src/pages/en/privacy.astro
+++ b/beta/src/pages/en/privacy.astro
@@ -4,7 +4,13 @@ import Nav from '../../components/Nav.astro';
 import Footer from '../../components/Footer.astro';
 ---
 
-<Layout title="Privacy Policy" lang="EN">
+<Layout
+  title="Privacy Policy"
+  lang="EN"
+  canonical="https://bumbleflies.de/en/privacy"
+  dePath="/datenschutz"
+  enPath="/en/privacy"
+>
   <Nav slot="nav" lang="EN" />
   <Footer slot="footer" lang="EN" />
   <div style="max-width: 800px; margin: 4rem auto; padding: 0 2rem; line-height: 1.8;">

--- a/beta/src/pages/impressum.astro
+++ b/beta/src/pages/impressum.astro
@@ -4,7 +4,12 @@ import Nav from '../components/Nav.astro';
 import Footer from '../components/Footer.astro';
 ---
 
-<Layout title="Impressum">
+<Layout
+  title="Impressum"
+  canonical="https://bumbleflies.de/impressum"
+  dePath="/impressum"
+  enPath="/en/imprint"
+>
   <Nav slot="nav" lang="DE" />
   <Footer slot="footer" lang="DE" />
   <div style="max-width: 800px; margin: 4rem auto; padding: 0 2rem; line-height: 1.8;">


### PR DESCRIPTION
Third PR from the `/ai-consulting` SEO review — fixes the legal-page canonical bug flagged in #96's description.

## Problem
`impressum`, `datenschutz`, `en/imprint` and `en/privacy` passed no `dePath`/`canonical` to `Layout`, so each emitted **the homepage URL** as its canonical (`https://bumbleflies.de/`). That tells Google these pages are duplicates of the homepage — they'd be dropped from the index in favour of `/`.

## Fix
Add explicit `canonical` + `dePath`/`enPath` to all four pages so they:
- self-canonicalise to their own URL, and
- carry correct DE↔EN `hreflang` pairing (impressum↔imprint, datenschutz↔privacy).

## Verification
`npm run build` ✓ (27 pages); confirmed in built HTML that each page's canonical is its own URL and hreflang pairs the correct translations. Unit tests ✓ (24/24).

Note: canonicals are written without trailing slash to match the existing codebase convention — #96's `withTrailingSlash()` normaliser adds the slash centrally once merged. Independent of #96 and #97 (different files); merges in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)