### PR TITLE
feat(ai-consulting): real build-pipeline section + genuine customer quote

### DIFF
--- a/beta/src/components/PipelineFlow.astro
+++ b/beta/src/components/PipelineFlow.astro
@@ -1,0 +1,240 @@
+---
+interface Props {
+  lang?: 'DE' | 'EN';
+}
+
+const { lang = 'DE' } = Astro.props;
+
+const t = {
+  DE: {
+    eyebrow: 'So bauen wir',
+    heading: 'Vom Ticket zum Release.',
+    sub: 'So entwickeln wir LeagueSphere — seit 2021 live, laufend erweitert. Du entscheidest, was gebaut wird. Agents bauen es. Ein Mensch bleibt am Steuer.',
+  },
+  EN: {
+    eyebrow: 'How we build',
+    heading: 'From ticket to release.',
+    sub: 'This is how we build LeagueSphere — live since 2021, continuously extended. You decide what gets built. Agents build it. A human stays at the wheel.',
+  },
+}[lang];
+
+// Each stage: short label lives in the SVG, title + description in the list below.
+const stages = [
+  {
+    n: '01', label: { DE: 'Issue', EN: 'Issue' },
+    title: { DE: 'Issue', EN: 'Issue' },
+    desc: {
+      DE: 'Ein Wunsch, Bug oder eine Idee wird als GitHub-Issue angelegt — in normaler Sprache.',
+      EN: 'A wish, bug or idea is filed as a GitHub issue — in plain language.',
+    },
+  },
+  {
+    n: '02', label: { DE: 'Triage', EN: 'Triage' },
+    title: { DE: 'Triage', EN: 'Triage' },
+    desc: {
+      DE: 'Ein autonomer Agent sichtet alle neuen Tickets und klassifiziert sie.',
+      EN: 'An autonomous agent sweeps every new ticket and classifies it.',
+    },
+  },
+  {
+    n: '03', label: { DE: 'Entscheidung', EN: 'Decision' }, human: true,
+    title: { DE: 'Entscheidung', EN: 'Decision' },
+    desc: {
+      DE: 'Ein Mensch prüft und entscheidet, was gebaut wird. Human-in-the-loop.',
+      EN: 'A human reviews and decides what gets built. Human-in-the-loop.',
+    },
+  },
+  {
+    n: '04', label: { DE: 'Build', EN: 'Build' },
+    title: { DE: 'Build', EN: 'Build' },
+    desc: {
+      DE: 'Unser Orchestrierungs-Framework und opencode implementieren test-getrieben (TDD) — bis zum Pull Request.',
+      EN: 'Our orchestration framework and opencode implement it test-first (TDD) — up to a pull request.',
+    },
+  },
+  {
+    n: '05', label: { DE: 'Review', EN: 'Review' }, loop: true,
+    title: { DE: 'Review-Loop', EN: 'Review loop' },
+    desc: {
+      DE: 'Ein Review- und Test-Bot dreht Runden, bis alles grün und freigegeben ist.',
+      EN: 'A review-and-test bot iterates until everything is green and approved.',
+    },
+  },
+  {
+    n: '06', label: { DE: 'Merge', EN: 'Merge' },
+    title: { DE: 'Automerge', EN: 'Automerge' },
+    desc: {
+      DE: 'Dann wird automatisch gemerged und ausgeliefert.',
+      EN: "Then it's merged and shipped automatically.",
+    },
+  },
+];
+
+// SVG layout — 6 nodes evenly spaced on a 1120×200 canvas.
+const cx = [60, 260, 460, 660, 860, 1060];
+const cy = 84;
+const r = 36;
+---
+
+<section class="a-pipeline bf-section">
+  <div class="bf-container">
+    <p class="bf-eyebrow a-pipeline__eyebrow">{t.eyebrow}</p>
+    <h2 class="a-pipeline__heading">{t.heading}</h2>
+    <p class="a-pipeline__sub">{t.sub}</p>
+
+    <svg class="a-pipeline__diagram" viewBox="0 0 1120 200" role="img"
+      aria-label={lang === 'DE'
+        ? 'Ablauf: Issue, Triage, Entscheidung, Build, Review-Loop, Automerge'
+        : 'Flow: Issue, Triage, Decision, Build, Review loop, Automerge'}>
+      <defs>
+        <marker id="pf-arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+          <path d="M0,0 L10,5 L0,10" class="a-pipeline__arrowhead" />
+        </marker>
+      </defs>
+
+      {cx.slice(0, -1).map((x, i) => (
+        <line class="a-pipeline__connector" x1={x + r + 4} y1={cy} x2={cx[i + 1] - r - 8} y2={cy} marker-end="url(#pf-arrow)" />
+      ))}
+
+      {stages.map((s, i) => (
+        <g class={`a-pipeline__node ${s.human ? 'is-human' : ''}`}>
+          <circle cx={cx[i]} cy={cy} r={r} class="a-pipeline__node-circle" />
+          <text x={cx[i]} y={cy + 6} class="a-pipeline__node-num" text-anchor="middle">{s.n}</text>
+          <text x={cx[i]} y={cy + r + 26} class="a-pipeline__node-label" text-anchor="middle">{s.label[lang]}</text>
+          {s.loop && (
+            <text x={cx[i]} y={cy - r - 8} class="a-pipeline__loop" text-anchor="middle">↻</text>
+          )}
+        </g>
+      ))}
+    </svg>
+
+    <ol class="a-pipeline__steps">
+      {stages.map((s) => (
+        <li class={`a-pipeline__step ${s.human ? 'is-human' : ''}`}>
+          <span class="a-pipeline__step-num">{s.n}</span>
+          <h3 class="a-pipeline__step-title">{s.title[lang]}</h3>
+          <p class="a-pipeline__step-desc">{s.desc[lang]}</p>
+        </li>
+      ))}
+    </ol>
+  </div>
+</section>
+
+<style>
+  .a-pipeline {
+    padding: 4rem 0;
+    background: var(--bg);
+  }
+  .a-pipeline__eyebrow {
+    margin: 0 0 1rem;
+  }
+  .a-pipeline__heading {
+    font-family: var(--font-display);
+    font-size: 2rem;
+    margin: 0 0 1rem;
+    color: var(--ink);
+  }
+  .a-pipeline__sub {
+    font-size: 1.15rem;
+    line-height: 1.6;
+    color: var(--ink-soft);
+    max-width: 720px;
+    margin: 0 0 3rem;
+  }
+
+  .a-pipeline__diagram {
+    display: block;
+    width: 100%;
+    height: auto;
+    max-width: 1000px;
+    margin: 0 auto 3rem;
+  }
+  .a-pipeline__connector {
+    stroke: var(--rule);
+    stroke-width: 2;
+  }
+  .a-pipeline__arrowhead {
+    fill: none;
+    stroke: var(--accent);
+    stroke-width: 1.6;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+  .a-pipeline__node-circle {
+    fill: var(--paper);
+    stroke: var(--rule);
+    stroke-width: 1.5;
+  }
+  .a-pipeline__node.is-human .a-pipeline__node-circle {
+    fill: var(--accent);
+    stroke: var(--accent);
+  }
+  .a-pipeline__node-num {
+    font-family: var(--font-mono);
+    font-size: 22px;
+    font-weight: 600;
+    fill: var(--accent);
+  }
+  .a-pipeline__node.is-human .a-pipeline__node-num {
+    fill: var(--paper);
+  }
+  .a-pipeline__node-label {
+    font-family: var(--font-mono);
+    font-size: 15px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    fill: var(--ink-soft);
+  }
+  .a-pipeline__loop {
+    font-size: 30px;
+    fill: var(--accent);
+  }
+
+  .a-pipeline__steps {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1.5rem;
+  }
+  .a-pipeline__step {
+    padding: 1.5rem;
+    border: 1px solid var(--rule);
+    border-radius: 8px;
+    background: var(--paper);
+  }
+  .a-pipeline__step.is-human {
+    border-color: var(--accent);
+  }
+  .a-pipeline__step-num {
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    color: var(--accent);
+    font-weight: 600;
+  }
+  .a-pipeline__step-title {
+    font-family: var(--font-display);
+    font-size: 1.35rem;
+    margin: 0.5rem 0 0.75rem;
+    color: var(--ink);
+  }
+  .a-pipeline__step-desc {
+    font-size: 0.95rem;
+    line-height: 1.55;
+    color: var(--ink-soft);
+    margin: 0;
+  }
+
+  @media (max-width: 900px) {
+    .a-pipeline__steps { grid-template-columns: repeat(2, 1fr); }
+  }
+  @media (max-width: 768px) {
+    .a-pipeline { padding: 2.5rem 0; }
+    .a-pipeline__heading { font-size: 1.5rem; }
+    .a-pipeline__sub { font-size: 1rem; margin-bottom: 2rem; }
+    /* On narrow screens the horizontal SVG gets too cramped; the list carries it. */
+    .a-pipeline__diagram { display: none; }
+    .a-pipeline__steps { grid-template-columns: 1fr; }
+  }
+</style>

--- a/beta/src/content/pages/ai-consulting.nt
+++ b/beta/src/content/pages/ai-consulting.nt
@@ -15,8 +15,8 @@ steps:
   - number: "04"
     title: Skalieren
     description: Der Pilot läuft? Dann rollen wir aus. Integration in deine Systeme, Training für dein Team, Begleitung bis zur Eigenständigkeit.
-quote: "Die meisten Probleme, die wir lösen, fangen als Gespräch an. Manche enden auch dort. Andere brauchen einen KI-Piloten. Wieder andere wollen gebaut werden. Wir machen alle drei."
-quoteCite: — Aus unserem Manifesto
+quote: "Gehe ich richtig in der Annahme, dass man Feature-Requests einfach textuell eingibt — und dann laufen Agents los, implementieren das, machen Pull-Requests? Ich habe die romantische Vorstellung, dass ihr da einen aktuellen Schatz habt."
+quoteCite: — aus einer echten Kundenanfrage
 ctaHeading: Lass uns
 ctaHeading_em: reden.
 ctaBody: Schreib uns zwei Sätze zu deinem Thema. Wir antworten innerhalb von 24h mit einer Einschätzung, ob und wie KI helfen kann.

--- a/beta/src/content/pages/en/ai-consulting.nt
+++ b/beta/src/content/pages/en/ai-consulting.nt
@@ -15,8 +15,8 @@ steps:
   - number: "04"
     title: Scale
     description: Pilot works? Then we roll out. Integration into your systems, training for your team, support until you're self-sufficient.
-quote: Most of the problems we solve start as a conversation. Some end there. Others need an AI pilot. Still others want to be built. We do all three.
-quoteCite: — From our manifesto
+quote: "Am I right in assuming you just type a feature request in plain text — and then agents kick off, implement it, open pull requests? I have this romantic notion that you're sitting on a real treasure here."
+quoteCite: — from a real customer inquiry
 ctaHeading: Let's
 ctaHeading_em: talk.
 ctaBody: Send us two sentences about your topic. We respond within 24h with an assessment of whether and how AI can help.

--- a/beta/src/pages/ai-consulting.astro
+++ b/beta/src/pages/ai-consulting.astro
@@ -3,6 +3,7 @@ import Layout from '../components/Layout.astro';
 import Nav from '../components/Nav.astro';
 import Quote from '../components/Quote.astro';
 import CTAStrip from '../components/CTAStrip.astro';
+import PipelineFlow from '../components/PipelineFlow.astro';
 import Footer from '../components/Footer.astro';
 import { getCollection } from 'astro:content';
 
@@ -99,6 +100,8 @@ let lang: 'DE' | 'EN' = 'DE';
       </div>
     </div>
   </section>
+
+  <PipelineFlow lang={lang} />
 
   <section class="a-ai-quote bf-section">
     <div class="bf-container">
@@ -224,7 +227,7 @@ let lang: 'DE' | 'EN' = 'DE';
   }
   .a-ai-quote {
     padding: 4rem 0;
-    background: var(--bg);
+    background: var(--paper);
     text-align: center;
   }
   @media (max-width: 768px) {

--- a/beta/src/pages/en/ai-consulting.astro
+++ b/beta/src/pages/en/ai-consulting.astro
@@ -3,6 +3,7 @@ import Layout from '../../components/Layout.astro';
 import Nav from '../../components/Nav.astro';
 import Quote from '../../components/Quote.astro';
 import CTAStrip from '../../components/CTAStrip.astro';
+import PipelineFlow from '../../components/PipelineFlow.astro';
 import Footer from '../../components/Footer.astro';
 import { getCollection } from 'astro:content';
 
@@ -75,6 +76,8 @@ const lang: 'DE' | 'EN' = 'EN';
       </div>
     </div>
   </section>
+
+  <PipelineFlow lang={lang} />
 
   <section class="a-ai-quote bf-section">
     <div class="bf-container">
@@ -198,7 +201,7 @@ const lang: 'DE' | 'EN' = 'EN';
   }
   .a-ai-quote {
     padding: 4rem 0;
-    background: var(--bg);
+    background: var(--paper);
     text-align: center;
   }
   @media (max-width: 768px) {


### PR DESCRIPTION
Gives `/ai-consulting` the "image and heart" it was missing — it made abstract claims with **no proof and no visual** (imgCount was literally 0).

## What's new
A concrete **"Vom Ticket zum Release" / "From ticket to release"** section anchored on **LeagueSphere** (live since 2021), showing how we *actually* build:

`GitHub issue → autonomous triage → human decides what to build (human-in-the-loop) → orchestration framework + opencode implement test-first (TDD) → review/test bot loops until approved → automerge`

- **`PipelineFlow.astro`** — a new bilingual component with an **on-brand inline SVG diagram**: 6 nodes, amber flow arrows, the human decision node highlighted in accent (the differentiator — *humans decide what, agents do how*), and a loop mark on the review stage. Supporting step grid below. Horizontal SVG on desktop, stacked cards on mobile, theme-aware.
- **Real customer quote** replaces the invented manifesto quote — an anonymised, genuine inquiry ("…Ich habe die romantische Vorstellung, dass ihr da einen aktuellen Schatz habt.") that captures real wonder at the process. Trimmed to what the diagram actually supports.
- Restored clean `--paper`/`--bg` alternation with the new section in place.

## Accuracy
Pipeline wording reflects the **real** LeagueSphere process (confirmed with the owner), not the customer's guess — no Claude/Gemini/CircleCI branding, since those aren't what's used.

## Verification
`npm run build` ✓ (27 pages); unit tests ✓ (24/24). Screenshotted desktop + mobile for both languages: diagram renders, human node highlighted, review loop shown, SVG hides and cards stack on mobile, backgrounds alternate cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)