### PR TITLE
feat(seo): retarget ai-consulting keywords + FAQ/Service/ProfessionalService schema

### DIFF
--- a/beta/src/components/Faq.astro
+++ b/beta/src/components/Faq.astro
@@ -1,0 +1,66 @@
+---
+interface FaqItem {
+  q: string;
+  a: string;
+}
+
+interface Props {
+  heading: string;
+  items: FaqItem[];
+}
+
+const { heading, items } = Astro.props;
+---
+
+<section class="a-faq bf-section">
+  <div class="bf-container">
+    <h2 class="a-faq__heading">{heading}</h2>
+    <dl class="a-faq__list">
+      {items.map((item) => (
+        <div class="a-faq__item">
+          <dt class="a-faq__q">{item.q}</dt>
+          <dd class="a-faq__a">{item.a}</dd>
+        </div>
+      ))}
+    </dl>
+  </div>
+</section>
+
+<style>
+  .a-faq {
+    padding: 4rem 0;
+    background: var(--paper);
+  }
+  .a-faq__heading {
+    font-family: var(--font-display);
+    font-size: 2rem;
+    margin: 0 0 2.5rem;
+    color: var(--ink);
+  }
+  .a-faq__list {
+    margin: 0;
+    border-top: 1px solid var(--rule);
+    max-width: 820px;
+  }
+  .a-faq__item {
+    padding: 1.75rem 0;
+    border-bottom: 1px solid var(--rule);
+  }
+  .a-faq__q {
+    font-family: var(--font-display);
+    font-size: 1.35rem;
+    color: var(--ink);
+    margin: 0 0 0.75rem;
+  }
+  .a-faq__a {
+    font-size: 1rem;
+    line-height: 1.6;
+    color: var(--ink-soft);
+    margin: 0;
+  }
+  @media (max-width: 768px) {
+    .a-faq { padding: 2.5rem 0; }
+    .a-faq__heading { font-size: 1.5rem; margin-bottom: 1.5rem; }
+    .a-faq__q { font-size: 1.2rem; }
+  }
+</style>

--- a/beta/src/components/Layout.astro
+++ b/beta/src/components/Layout.astro
@@ -15,6 +15,8 @@ interface Props {
   noindex?: boolean;
   dePath?: string;
   enPath?: string;
+  /** Page-specific JSON-LD (e.g. Service, FAQPage), rendered in addition to the global Organization schema. */
+  jsonLd?: Record<string, unknown> | Record<string, unknown>[];
 }
 
 const {
@@ -26,7 +28,12 @@ const {
   noindex = false,
   dePath,
   enPath,
+  jsonLd: pageJsonLd,
 } = Astro.props;
+
+const pageSchemas = pageJsonLd
+  ? (Array.isArray(pageJsonLd) ? pageJsonLd : [pageJsonLd])
+  : [];
 
 const htmlLang = lang === 'DE' ? 'de' : 'en';
 
@@ -55,17 +62,31 @@ const ogImageUrl = ogImage.startsWith('http') ? ogImage : `${SITE_URL}${ogImage}
 
 const jsonLd = JSON.stringify({
   "@context": "https://schema.org",
-  "@type": "Organization",
+  "@type": "ProfessionalService",
   "name": "bumbleflies",
   "url": SITE_URL,
   "description": DEFAULT_DESCRIPTION,
   "foundingDate": "2021",
-  "knowsAbout": ["Facilitation", "AI Consulting", "App Development"],
+  "email": "info@bumbleflies.de",
+  "knowsAbout": [
+    "AI Consulting",
+    "Agentic Software Development",
+    "Human-in-the-Loop AI",
+    "Facilitation",
+    "App Development",
+    "Conversation to Code"
+  ],
+  "areaServed": ["Munich", "Germany", "DACH"],
   "address": {
     "@type": "PostalAddress",
     "addressLocality": "Munich",
     "addressCountry": "DE"
-  }
+  },
+  "sameAs": [
+    "https://de.linkedin.com/company/bumbleflies",
+    "https://github.com/bumbleflies",
+    "https://social.bumbleflies.de"
+  ]
 });
 ---
 
@@ -102,6 +123,9 @@ const jsonLd = JSON.stringify({
     {deUrl && enUrl && <link rel="alternate" hreflang="x-default" href={deUrl} />}
 
     <script type="application/ld+json" set:html={jsonLd}></script>
+    {pageSchemas.map((schema) => (
+      <script type="application/ld+json" set:html={JSON.stringify(schema)}></script>
+    ))}
 
     <script is:inline>
       const theme = (() => {

--- a/beta/src/pages/ai-consulting.astro
+++ b/beta/src/pages/ai-consulting.astro
@@ -4,6 +4,7 @@ import Nav from '../components/Nav.astro';
 import Quote from '../components/Quote.astro';
 import CTAStrip from '../components/CTAStrip.astro';
 import PipelineFlow from '../components/PipelineFlow.astro';
+import Faq from '../components/Faq.astro';
 import Footer from '../components/Footer.astro';
 import { getCollection } from 'astro:content';
 
@@ -21,15 +22,63 @@ const deContent = dePage.data;
 const enContent = enPage.data;
 
 let lang: 'DE' | 'EN' = 'DE';
+
+const pageTitle = 'Agentische Softwareentwicklung & KI-Beratung | bumbleflies';
+const pageDescription = 'Wir bauen deine Software mit autonomen KI-Agenten und Human-in-the-Loop — vom Ticket zum Release. KI-Beratung, die liefert: From Conversation to Code.';
+
+const faqItems = [
+  {
+    q: 'Kann KI Feature-Requests selbstständig umsetzen?',
+    a: 'Ja. Aus einem GitHub-Issue in normaler Sprache wird über autonome Agenten ein fertiger Pull Request — test-getrieben (TDD), mit einem Review- und Test-Loop bis zur Freigabe und Automerge.',
+  },
+  {
+    q: 'Wie bleibt der Mensch in Kontrolle (Human-in-the-Loop)?',
+    a: 'Ein Mensch entscheidet, was gebaut wird. Die Agents übernehmen die Umsetzung; ein Review- und Test-Bot dreht Runden, bis alles grün ist. Du gibst die Richtung vor, ein Mensch bleibt am Steuer.',
+  },
+  {
+    q: 'Was bedeutet „From Conversation to Code"?',
+    a: 'Vom ersten Gespräch über die Strategie bis zur laufenden Software: Wir verstehen, entscheiden, pilotieren und skalieren — echte Software statt PowerPoint.',
+  },
+  {
+    q: 'Wie schnell steht ein funktionierender Prototyp?',
+    a: 'In 4–6 Wochen bauen wir einen funktionalen Prototypen. Keine Mockups, echte Software — in deinem Kontext.',
+  },
+  {
+    q: 'Mit welchen Tools arbeitet ihr?',
+    a: 'GitHub für Issues und Pull Requests, ein eigenes Orchestrierungs-Framework und opencode für die Umsetzung, test-getrieben (TDD), mit automatisiertem Review- und Test-Loop.',
+  },
+];
+
+const serviceSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'Service',
+  serviceType: 'AI Consulting & Agentic Software Development',
+  name: 'KI-Beratung & agentische Softwareentwicklung',
+  description: pageDescription,
+  provider: { '@type': 'Organization', name: 'bumbleflies', url: 'https://bumbleflies.de' },
+  areaServed: ['Munich', 'Germany', 'DACH'],
+  url: 'https://bumbleflies.de/ai-consulting/',
+};
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqItems.map((item) => ({
+    '@type': 'Question',
+    name: item.q,
+    acceptedAnswer: { '@type': 'Answer', text: item.a },
+  })),
+};
 ---
 
 <Layout
-  title={deContent.title}
-  description="Vom ersten Gespräch zur laufenden KI-Lösung. Wir helfen dir, KI nicht nur zu verstehen, sondern einzusetzen — Conversation to Code in Tagen, nicht Monaten."
+  title={pageTitle}
+  description={pageDescription}
   canonical="https://bumbleflies.de/ai-consulting"
   lang={lang}
   dePath="/ai-consulting"
   enPath="/en/ai-consulting"
+  jsonLd={[serviceSchema, faqSchema]}
 >
   <div slot="nav">
     <Nav lang={lang} />
@@ -37,7 +86,7 @@ let lang: 'DE' | 'EN' = 'DE';
 
   <section class="a-ai-hero">
     <div class="bf-container">
-      <p class="a-ai-hero__label" data-de="AI Consulting" data-en="AI Consulting">AI Consulting</p>
+      <p class="a-ai-hero__label" data-de="KI-Beratung · Agentische Entwicklung" data-en="AI Consulting · Agentic Development">KI-Beratung · Agentische Entwicklung</p>
       <h1 class="a-ai-hero__heading" data-de={deContent.heading} data-en={enContent.heading}>
         {deContent.heading}
       </h1>
@@ -102,6 +151,8 @@ let lang: 'DE' | 'EN' = 'DE';
   </section>
 
   <PipelineFlow lang={lang} />
+
+  <Faq heading="Häufige Fragen" items={faqItems} />
 
   <section class="a-ai-quote bf-section">
     <div class="bf-container">
@@ -228,7 +279,7 @@ let lang: 'DE' | 'EN' = 'DE';
   }
   .a-ai-quote {
     padding: 4rem 0;
-    background: var(--paper);
+    background: var(--bg);
     text-align: center;
   }
   @media (max-width: 768px) {

--- a/beta/src/pages/en/ai-consulting.astro
+++ b/beta/src/pages/en/ai-consulting.astro
@@ -4,6 +4,7 @@ import Nav from '../../components/Nav.astro';
 import Quote from '../../components/Quote.astro';
 import CTAStrip from '../../components/CTAStrip.astro';
 import PipelineFlow from '../../components/PipelineFlow.astro';
+import Faq from '../../components/Faq.astro';
 import Footer from '../../components/Footer.astro';
 import { getCollection } from 'astro:content';
 
@@ -16,15 +17,63 @@ if (!enPages[0]) {
 const content = enPages[0].data;
 
 const lang: 'DE' | 'EN' = 'EN';
+
+const pageTitle = 'Agentic Software Development & AI Consulting | bumbleflies';
+const pageDescription = 'We build your software with autonomous AI agents and human-in-the-loop — from ticket to release. AI consulting that delivers: from Conversation to Code.';
+
+const faqItems = [
+  {
+    q: 'Can AI implement feature requests on its own?',
+    a: 'Yes. A GitHub issue written in plain language becomes a finished pull request via autonomous agents — test-first (TDD), with a review-and-test loop until approval and automerge.',
+  },
+  {
+    q: 'How does a human stay in control (human-in-the-loop)?',
+    a: 'A human decides what gets built. Agents handle the implementation; a review-and-test bot iterates until everything is green. You set the direction, a human stays at the wheel.',
+  },
+  {
+    q: 'What does "From Conversation to Code" mean?',
+    a: 'From the first conversation through strategy to running software: we understand, decide, pilot and scale — real software, not slideware.',
+  },
+  {
+    q: 'How fast is a working prototype?',
+    a: 'In 4–6 weeks we build a functional prototype. No mockups, real software — in your context.',
+  },
+  {
+    q: 'Which tools do you use?',
+    a: 'GitHub for issues and pull requests, our own orchestration framework and opencode for implementation, test-first (TDD), with an automated review-and-test loop.',
+  },
+];
+
+const serviceSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'Service',
+  serviceType: 'AI Consulting & Agentic Software Development',
+  name: 'AI Consulting & Agentic Software Development',
+  description: pageDescription,
+  provider: { '@type': 'Organization', name: 'bumbleflies', url: 'https://bumbleflies.de' },
+  areaServed: ['Munich', 'Germany', 'DACH'],
+  url: 'https://bumbleflies.de/en/ai-consulting/',
+};
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqItems.map((item) => ({
+    '@type': 'Question',
+    name: item.q,
+    acceptedAnswer: { '@type': 'Answer', text: item.a },
+  })),
+};
 ---
 
 <Layout
-  title={content.title}
-  description="From the first conversation to a running AI solution. We help you not just understand AI, but deploy it — Conversation to Code in days, not months."
+  title={pageTitle}
+  description={pageDescription}
   canonical="https://bumbleflies.de/en/ai-consulting"
   lang={lang}
   dePath="/ai-consulting"
   enPath="/en/ai-consulting"
+  jsonLd={[serviceSchema, faqSchema]}
 >
   <div slot="nav">
     <Nav lang={lang} />
@@ -32,7 +81,7 @@ const lang: 'DE' | 'EN' = 'EN';
 
   <section class="a-ai-hero">
     <div class="bf-container">
-      <p class="a-ai-hero__label">AI Consulting</p>
+      <p class="a-ai-hero__label">AI Consulting · Agentic Development</p>
       <h1 class="a-ai-hero__heading">{content.heading}</h1>
       <p class="a-ai-hero__subheading">{content.subheading}</p>
     </div>
@@ -78,6 +127,8 @@ const lang: 'DE' | 'EN' = 'EN';
   </section>
 
   <PipelineFlow lang={lang} />
+
+  <Faq heading="Frequently asked questions" items={faqItems} />
 
   <section class="a-ai-quote bf-section">
     <div class="bf-container">
@@ -202,7 +253,7 @@ const lang: 'DE' | 'EN' = 'EN';
   }
   .a-ai-quote {
     padding: 4rem 0;
-    background: var(--paper);
+    background: var(--bg);
     text-align: center;
   }
   @media (max-width: 768px) {


### PR DESCRIPTION
Acts on the SEO discoverability analysis. Live-search testing showed bumbleflies surfaces for **brand** queries but is absent for the **topic** the customer was actually curious about (autonomous agents building software, human-in-the-loop). The page had the content but not the ranking signals. These are the agreed **quick wins**.

## Changes
**1. Retarget metadata to the winnable long-tail** (DE + EN)
- Title now leads with the differentiated term: `Agentische Softwareentwicklung & KI-Beratung` / `Agentic Software Development & AI Consulting` (was generic `AI Consulting — From Conversation to Code`).
- Meta description + hero eyebrow now carry `autonome KI-Agenten`, `Human-in-the-Loop`, `vom Ticket zum Release`. Stops competing only for the hyper-competitive generic `KI-Beratung`.

**2. Visible FAQ + `FAQPage` schema**
- New `Faq.astro` (editorial Q&A, on-brand, theme-aware) answering the customer's literal questions ("Kann KI Feature-Requests selbstständig umsetzen?", "Wie bleibt der Mensch in Kontrolle?", tools, speed, "Conversation to Code").
- Backed by matching `FAQPage` JSON-LD — targets informational "how does it work" queries (visible content, per Google guidelines).

**3. Richer structured data**
- `Service` schema for the offering.
- Global `Organization` → `ProfessionalService` with real `sameAs` (LinkedIn/GitHub/Mastodon) + `areaServed` (Munich/Germany/DACH).
- New optional `jsonLd` prop on `Layout` for page-specific schema.

## Verification
`npm run build` ✓ (27 pages); all 3 JSON-LD blocks parse valid (ProfessionalService, Service, FAQPage w/ 5 Q&A); FAQ renders visibly; unit tests ✓ (24/24). Screenshotted the FAQ section.

## Not included (bigger, needs you)
- The **deep-dive article** ("Vom Ticket zum Release … am Beispiel LeagueSphere") — the highest-leverage move, but it's real writing about your process; scope separately.
- **Backlinks / Google Business Profile** — off-site; a full `LocalBusiness` listing needs the street address I don't have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)