### PR TITLE
feat(blog): anonymized AI-agent "Field Notes" series with per-article live switch

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -1,13 +1,11 @@
-# Sample workflow for building and deploying a Jekyll site to GitHub Pages
+# Legacy Jekyll site (archived at archive.bumbleflies.de).
+# DISABLED from automatic runs: the production site is built and deployed by
+# astro-build-deploy.yml. Jekyll swept in the Astro content under beta/ and its
+# old multiple-languages plugin fails on it, so this pipeline is manual-only.
+# Re-enable by restoring the push/pull_request triggers below.
 name: Build & Deploy
 
 on:
-  # Runs on pushes targeting the default branch
-  push:
-  pull_request:
-    branches:
-      - "*"
-
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/beta/.astro/content.d.ts
+++ b/beta/.astro/content.d.ts
@@ -85,6 +85,10 @@ declare module 'astro:content' {
 		entry: DataEntryMap[C][string],
 	): Promise<RenderResult>;
 
+	export function render<C extends keyof LiveContentConfig['collections']>(
+		entry: import('astro').LiveDataEntry<LiveLoaderDataType<C>>,
+	): Promise<RenderResult>;
+
 	export function reference<
 		C extends
 			| keyof DataEntryMap
@@ -120,7 +124,15 @@ declare module 'astro:content' {
 		: any;
 
 	type DataEntryMap = {
-		"case-studies": Record<string, {
+		"blog": Record<string, {
+  id: string;
+  body?: string;
+  collection: "blog";
+  data: InferEntrySchema<"blog">;
+  rendered?: RenderedContent;
+  filePath?: string;
+}>;
+"case-studies": Record<string, {
   id: string;
   body?: string;
   collection: "case-studies";

--- a/beta/public/images/blog/bots-die-nachts-arbeiten-light.svg
+++ b/beta/public/images/blog/bots-die-nachts-arbeiten-light.svg
@@ -1,0 +1,162 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 675" width="1200" height="675" role="img" aria-label="Konzept (hell): autonome Bots wie Gluehwuermchen arbeiten ueber einer ruhenden Stadt, oeffnen einen PR und werden vor dem master-Zweig gestoppt">
+<defs>
+<style>@font-face{font-family:'Mo';src:url(data:font/woff2;base64,d09GMgABAAAAAA7QAA8AAAAAHEwAAA53AAGzMwAAAAAAAAAAAAAAAAAAAAAAAAAAGigbIBwqBmA/U1RBVEgAgX4RCAqsLKJ4ATYCJAOCTguBKgAEIAVmByAb5RWjolZyVsaI/uKAJ0MfBYTACKR2WmgcqlNCrcK+9m3czlmg3OwcHiCxvo6QZPbncdv/GWET8qJtEERBQImSHOxSEy4D5oysF+n7WcHPCHmA7t3721fDDjigCbQtoDzwkMOAozGBw67/AcA5+31rZVXPhOpPB4AUsDtw9+LTsEznE561Gxt1gDZhjaQWB8+J0MAycHtU/O9aafMPyBVQIQrZs301proS/yazu8nm/l7miHgKQG6riFzVTAFIWJa1FfKUqxCyklRf5gzEKs6tRLzvreZMHlPkAjmAW1N4Du46AgGgyKk1jwChGpTK4D5GrWGMkYPXe9kCO5Ug5nNhDHkEAGAdmFjlMxWUeFcn3hdnxmBrLQA3QZrmkxSAd/QqCCC0mIfYkT5xVvASyK94+l74Tq/FLLxheEgIG/nf/d9CMOZjFN8MeDUvC5TJMbV9Hh6AjXdWVXaoD8xUE/+FsQk5KkEN+IxnJye9uSdiRRhSOCO4ilwNdTXBxgh8/TFrlBEoUEZFy8LKLSaJNWvJnc4urh6+fv4NG9fXAZRRqlUPa+5BY3SaU0pzLwCx4viQUqUOeQCcbOwYK62ceZuJByicVqLMx0aiKBElypSrUKmKnEI1FbVadTS0dPQMGhiZEIiIBAAAnsJV3v0gZ0uQ3wOAFQMcgOL1ivAhjlwQn/HSiTz8pMi5AEJMxSRQY3men2qBU0UMz7qKfQw4lnx6r0ogy88vKcwvKqyWFhULrmfPlRZJpaJ8gbR4S74uT5YnLcovqC7aIi6xLltziwTloi0iSRG3qN4qLdosXnps06qLBJtyRV9NgeBbz0JBhbaQL68Qt2MP/nIEuYLLlsmWZ9QE8shKLuO9ttiCZy/Fz1CY+dyIS0z7uftJACYXe9/Y/iedxprdSK/bUKx8ZeOtFAKsebAp5io0RXQV2J5VenvFaaPzm0zOCUOJu7Am0EPN6KkAoQTTowa89RHWJCGIR7rzTQwHZt748VxHozbUqbvVQRbmUjmn67cgK3mmMunc5v4tfnHrUKiD32TpDJ8HdRnpTLGoIACnTiHpiLvY5wJ+9NbB0chacSv6Lxehu16fy2+ZCD92Y3/olTmCVH7KSEFbvUV4F4nJwtURVqcj5xxlmMBMHpVBOoVkGomkpBI6wLdU4HbEmhqarA39ve9+0juOO9mPJooBQM+h9MK7k1g6QtKazfdEvK41/ZOHjJwR6uhi7jdUwZnDq3lnzEa+JmNzztm1jpGleR+Gh19qljughLpWO3nkE0VeMqfscHpK1zDYUssByGubUJhiTdUnn/TL62V+5hePkNMus4fMMLVm+U3ui2IL1MHVOl9JYHiI4soOpnVLBRKxXDU5xywqC+NHmqC8iUmKM9S9pZt1h7qXwgJHdDnswU3Q8hAimT+AvjmKagdZvZWidvQCZyj5LGQpqe+LtAT/QOWDnTsvwf9zuHzm9f0eCX+WgTHlWgXswYnnFhreUDOYetavvyVd/ndO0Vd48OiEWcj+Sm+hmP25PRp90SADQaHPzzdHf2gVGBiyqjHSVzBJR+l1pQDVWFPU1obCB4Yzj0mdeYh1nqQSrTbJ+jRnXkKFOHZTqrVZWgRcb72sciG+biu29/Ieg3tdfM0ISQqtJf7f/v6w/d+W/YwjGvOf9GEt/aNJ6jeHMuZv3t7uePVMwz2yjiOuI14iqaSDUAotbndJ0pqixMHF/R8xEP2BzpG4cuUNzcW42HRfEiZz7dXwIiKf4I/8dfsQd45FzvZpTG3B6UMxMHH5PH7iL7Qasj3U2swLBlkvLmTsQ9zzrIkqdlFxXDnPY2iaGNRSJoRMhzFK5U/enLOSo5Mf3nvmyeFun1c10qd2JcTwxwNs9snZuX62VuUPVetznGmVJtTA7RmcPCZxXCRoM1pCTeg4PIe8lkaj14LmoE6SnM3YL5+atl8+yybbDixtGm0RSsPxiNkS9lTv5Vqq94Q9FmcyKcasQDZz6CCw2au4tTi6YGoKnb/WzDUnIgNTh48cmVobiACbvQmzn0Xj0S+6MPRk74ofs7CNjtN6UElCM3HvZUvTzstn2YS7x+LtE3syQqk7mmgyRTzKvVyLak/UYzEEG1RtO6+J/91P86+cf7k+Fq4Fe5bJ3HzczRkmy7TK/q1A45tLbsZ3Lb4BkEnIfpt1jECJXF6SSiCEcPJN5s251SNw5KMZw/jQV49nmWzDH/33yy+HnixzwbXHYxDGDsnz5pjs/mMDSnzg/iwzl3dIDmR2qWDt4+OYresnx4NagmeS9svnFghZY5y0MHePRMIUdlXvaW2t3ht2m3zpRh/IPTk3YLNvolGDrcPnI5TPhPZvHFjAMZ/LHfPiBVie20czy+Fd3sf3WlS/qoObB8k5I38xE/smuvV14YA6biP5pE3oLX6GkT5UtubRnFYytR9FPA5nxI32g1ESmnb4R4SBjLBHQyG5Xu/dWlZZ8SGuiW+mNrJ6ZbDRbmYH9RTVb7X35royQlbuccvrPRGnofxpqswjY7b02WqbbWYHM6oFYuotnIffmgK1ZGLP8UvPM8+noy2hEKm0K5cyPeDX0ePc/cdvfSTnuMFI5HHWfWpBxMuBLADJhiX7Ke1W7An6R3se7Og5ZadapuvBzke7e84oWwZ4FW9d2nVxyLPrjUsrQM8cu2MJv31+B6dh+KxQH6usc6l9NGKkN1f67G6L6cX70zliNMGxHYNTve/K/pNWIPqkoorPJnKknWSsRE4ZA1WVnlrNxaWZs8rlSggX1vh3bHz0ecF8OIsVB9d+8JfWkL1e43IyaZB/kijmDQ+2cOEBt86vqUo57VVpnxYshWjUa1vB2LY86kO2lhpb8zUp4W2k2UDFBzguPkAZkO3elPAaB9OqhYJCjv/wpNpX+sPaQQXOhgXzz99a5d9RFav3aavSdmdVyq/RucMDXEt4EHSFoRGvdQVj6/KQj/IPumzLmW37BZhO+hs89U9kcjaSM+z3PoUwHAnYHFEErzYEgih0DbqmNKe84aMn0CMIlBdbWuQO//Up4W1PO4Jhi5VRJXQN3gG3dToUtkz1uT3mtGEHpr93mtL9GiTyNbdBc05V1FejIcNt8Xi0DXqyWHXyuX/4t6ssUb2StSWxI2KkzK5wBNmBRq9dufYrKn3yTnQnhtHT0VXVnfXfrG1CLhkVCNPAZvFLxM6JFz98u77v+j/6R48B6a7tZYayVbSPQojaqNyFPkSglEV4sycfY/VptHqv0F1wvDNQ77Kk+jowDrxZtulvVV0cY98z5XsbcPcHHz7rgjC1S+WgG1WsOYkdyBK2q9wVCo/OAepCauTZsCRyiMLTlpPYttIyGKPoAY4joibPArHTr4oS87c7uCZHrCeiXaUoQLhXTEXuIPbdn3f6W/5of2srjJZf41FXpdzuypRXDbmn47z79xHkDlUTNyfXVHc7MR/96jltL1TigUwa+m8FsOjWIy+s3YpezD1+Ntfn9VhGwyPV0XtqS+ZfRNBY6O/WmmldSjhBmppsrvKqLa23nR0WMUqHWlMXyKjcnrTGEF5NCVsKglXW1YodF57yR3NRRmmr1Ro9bZVA/+5t7OxocHeN9sZ9SYYUwC2sTp8wth0YXnDRrhh2uGqGwiXW2lit09/UqL3HaQ8E3b/DUiQUQP/if+WyyhPQa0+g1xHkFMZah9qS2BkxBi3OAB2wYxl9ICtxZUj443sxd/69t+QwB1YH/Brf3ZHx+INvC66/eMgfWZ4FjI9I7iK6jnniyBM9d/If0l2nvCbeF46cjhw7L+oq3/VYLnfR3Wfczb2Ov76zEeI4Nk2iS5aeaQTzvVv+i/HNst2TkYmM7fKp6RYTbCQ6zrKZngK38UwkoSf9ir2pjEDI1esCfkImhfD/BnaK70Edis9iSjJrxB9i0Ic0C3Ojg6b8e2+ukv/+gzbERAoCGWFh/5HlaarfYOQcxsoo9lKKnxh/rWv7MRjkkunlMUEqLRS6sMmlDm39sl57XnCnxozN8tdcSpPf7PH6GscywvzYfFe/v1djTNo8cZoWy5j83v6oz90+rYOD53DR5Hvcmwxmzsl8J+gAlcTfp7NnUEa4HLU7/HEc0lcGPQptTVgp5DQnLGF1qXD9f9Onpb4+p3k0EHCMjTigTkJPBK3H96Z3nu2aGfLEmlIqY+ilTO7dF9tsCY/mENGz4dIRuspA9tssI1TUOTFmDyTIZDqG6KS3PqRQB3Q6RShQAw+N2d+efC7K7scfRj2hjtMdZ+26hAW1hJzUulv9kZaeUPGGh1DYYzalOvRNTZ16Y8rsocIvbggXsz0Rv7t1QksmyIzL64whOkYjpzfj8nMWn9li8NhsVq/NAHmgek3fFR/Xtxo3W23YUzdm3E6umqIpmnnO75dWluCHixsvNi4tTNiuheHRDXyOpmeF+X9iAzHY8G+0PgrdoxEfPqHsJIoSKH2yByITJ5afEAxij8QJKAC/zGOLnj8n4kRE4vqt4aqernQXQ2mwPuXvP4AYkwtxdVuUXJp8C5SwnNCPJK3ESYldMTVR7dHapDjEmKL+0pQgRmUQ+9l7wS+nwbWPcO3dC1sBYDsAz8lfBsX6jzy9ADvs9Dau/8pT8J4gGoBXL6aPrQ/xXcqahxLJQiLxZ8n3AMSu/gX4RY869bLErYaidWdtu8T+Wx6f/yUBwGfpa1Jws1+l//9l/H+Od4KgAsK891bWuzHDS1cT/rtPkBynmgTxKz1mwvYrsKCIZaknDXagSYmhB/RElm+voAK5XW1dAVRyBT0pgYwALJH51IQDKoiexo4RWwZKwGQFokUSix1pYgE2ghEaKJ5HdhbWm7upfAD4nn6c8CuM0ILI0EUwWjHg6gQQAHDypxqDihBOmp/OEzCiAXk+8IgBXowAKCIGeex2rXiLes+4Xv1mjeg0JWVXg9ZrwAzKjE4jonW3uHGjEB57Tzp5fY1OBoQT) format('woff2');}</style>
+<radialGradient id="ground" cx="46%" cy="48%" r="80%">
+  <stop offset="0%" stop-color="#fdfaf3"/><stop offset="58%" stop-color="#f3ecdb"/><stop offset="100%" stop-color="#e4d9c1"/>
+</radialGradient>
+<radialGradient id="coreglow" cx="50%" cy="50%" r="50%">
+  <stop offset="0%" stop-color="#ffdd93" stop-opacity="0.55"/><stop offset="55%" stop-color="#f2c46a" stop-opacity="0.16"/><stop offset="100%" stop-color="#f0ab4c" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="heart" cx="50%" cy="50%" r="50%">
+  <stop offset="0%" stop-color="#ffe3a0" stop-opacity="0.55"/><stop offset="60%" stop-color="#f0ab4c" stop-opacity="0.12"/><stop offset="100%" stop-color="#f0ab4c" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="halo" cx="50%" cy="50%" r="50%">
+  <stop offset="0%" stop-color="#f6bf5c" stop-opacity="0.7"/><stop offset="100%" stop-color="#f6bf5c" stop-opacity="0"/>
+</radialGradient>
+<linearGradient id="cell" x1="0" y1="0" x2="0" y2="1">
+  <stop offset="0%" stop-color="#f0b957"/><stop offset="55%" stop-color="#d5923c"/><stop offset="100%" stop-color="#b0742c"/>
+</linearGradient>
+<linearGradient id="hot" x1="0" y1="0" x2="0" y2="1">
+  <stop offset="0%" stop-color="#ffe6a6"/><stop offset="50%" stop-color="#f6c065"/><stop offset="100%" stop-color="#dc9d3e"/>
+</linearGradient>
+<linearGradient id="screen" x1="0" y1="0" x2="0" y2="1">
+  <stop offset="0%" stop-color="#ffe7ad"/><stop offset="100%" stop-color="#e6ab52"/>
+</linearGradient>
+<linearGradient id="panel" x1="0" y1="0" x2="0" y2="1">
+  <stop offset="0%" stop-color="#fffaf0"/><stop offset="100%" stop-color="#f4e8d0"/>
+</linearGradient>
+<radialGradient id="vig" cx="50%" cy="46%" r="66%">
+  <stop offset="62%" stop-color="#8a6a34" stop-opacity="0"/><stop offset="100%" stop-color="#8a6a34" stop-opacity="0.16"/>
+</radialGradient>
+<filter id="glow" x="-120%" y="-120%" width="340%" height="340%"><feGaussianBlur stdDeviation="6"/></filter>
+<filter id="glowbig" x="-150%" y="-150%" width="400%" height="400%"><feGaussianBlur stdDeviation="11"/></filter>
+<filter id="softbig" x="-60%" y="-60%" width="220%" height="220%"><feGaussianBlur stdDeviation="24"/></filter>
+<filter id="lift" x="-40%" y="-40%" width="180%" height="200%"><feDropShadow dx="0" dy="6" stdDeviation="11" flood-color="#6e4e24" flood-opacity="0.26"/></filter>
+<filter id="grain"><feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="2" stitchTiles="stitch"/>
+  <feColorMatrix type="matrix" values="0 0 0 0 0.42  0 0 0 0 0.30  0 0 0 0 0.12  0 0 0 0.5 0"/></filter>
+</defs>
+<rect width="1200" height="675" fill="url(#ground)"/>
+<ellipse cx="1046" cy="112" rx="130" ry="130" fill="url(#coreglow)" filter="url(#softbig)"/>
+<circle cx="1046" cy="112" r="46" fill="#f0c46a"/>
+<circle cx="1066" cy="102" r="44" fill="#f4ecdb"/>
+<circle cx="565" cy="137" r="0.9" fill="#d59a44" opacity="0.51"/>
+<circle cx="67" cy="171" r="1.5" fill="#d59a44" opacity="0.27"/>
+<circle cx="664" cy="200" r="0.8" fill="#d59a44" opacity="0.36"/>
+<circle cx="827" cy="158" r="1.4" fill="#d59a44" opacity="0.30"/>
+<circle cx="319" cy="69" r="1.2" fill="#d59a44" opacity="0.53"/>
+<circle cx="704" cy="241" r="1.1" fill="#d59a44" opacity="0.47"/>
+<circle cx="171" cy="116" r="1.3" fill="#d59a44" opacity="0.47"/>
+<circle cx="520" cy="63" r="1.0" fill="#d59a44" opacity="0.31"/>
+<circle cx="366" cy="250" r="1.0" fill="#d59a44" opacity="0.52"/>
+<circle cx="1019" cy="54" r="1.1" fill="#d59a44" opacity="0.40"/>
+<circle cx="86" cy="150" r="1.5" fill="#d59a44" opacity="0.28"/>
+<circle cx="711" cy="72" r="1.3" fill="#d59a44" opacity="0.52"/>
+<circle cx="281" cy="42" r="0.9" fill="#d59a44" opacity="0.41"/>
+<circle cx="79" cy="62" r="1.2" fill="#d59a44" opacity="0.53"/>
+<g>
+<rect x="-10" y="463" width="65" height="217" fill="#cdbfa3" stroke="#a9967a" stroke-opacity="0.6" stroke-width="1"/>
+<rect x="58" y="438" width="72" height="242" fill="#cdbfa3" stroke="#a9967a" stroke-opacity="0.6" stroke-width="1"/>
+<rect x="132" y="430" width="63" height="250" fill="#cdbfa3" stroke="#a9967a" stroke-opacity="0.6" stroke-width="1"/>
+<rect x="164" y="521" width="5" height="6" fill="#c88a30" opacity="0.54"/>
+<rect x="175" y="502" width="5" height="6" fill="#c88a30" opacity="0.56"/>
+<rect x="180" y="501" width="5" height="6" fill="#c88a30" opacity="0.72"/>
+<rect x="199" y="485" width="66" height="195" fill="#cdbfa3" stroke="#a9967a" stroke-opacity="0.6" stroke-width="1"/>
+<rect x="227" y="512" width="5" height="6" fill="#c88a30" opacity="0.65"/>
+<rect x="268" y="507" width="82" height="173" fill="#cdbfa3" stroke="#a9967a" stroke-opacity="0.6" stroke-width="1"/>
+<rect x="323" y="539" width="5" height="6" fill="#c88a30" opacity="0.68"/>
+<rect x="354" y="460" width="80" height="220" fill="#cdbfa3" stroke="#a9967a" stroke-opacity="0.6" stroke-width="1"/>
+<rect x="375" y="541" width="5" height="6" fill="#c88a30" opacity="0.55"/>
+<rect x="372" y="533" width="5" height="6" fill="#c88a30" opacity="0.42"/>
+<rect x="444" y="398" width="54" height="282" fill="#cdbfa3" stroke="#a9967a" stroke-opacity="0.6" stroke-width="1"/>
+<rect x="483" y="491" width="5" height="6" fill="#c88a30" opacity="0.42"/>
+<rect x="483" y="458" width="5" height="6" fill="#c88a30" opacity="0.62"/>
+<rect x="501" y="444" width="50" height="236" fill="#cdbfa3" stroke="#a9967a" stroke-opacity="0.6" stroke-width="1"/>
+<rect x="528" y="462" width="5" height="6" fill="#c88a30" opacity="0.68"/>
+<rect x="554" y="419" width="79" height="261" fill="#cdbfa3" stroke="#a9967a" stroke-opacity="0.6" stroke-width="1"/>
+<rect x="612" y="487" width="5" height="6" fill="#c88a30" opacity="0.42"/>
+<rect x="567" y="519" width="5" height="6" fill="#c88a30" opacity="0.41"/>
+<rect x="638" y="453" width="54" height="227" fill="#cdbfa3" stroke="#a9967a" stroke-opacity="0.6" stroke-width="1"/>
+<rect x="698" y="447" width="70" height="233" fill="#cdbfa3" stroke="#a9967a" stroke-opacity="0.6" stroke-width="1"/>
+<rect x="774" y="435" width="69" height="245" fill="#cdbfa3" stroke="#a9967a" stroke-opacity="0.6" stroke-width="1"/>
+<rect x="785" y="505" width="5" height="6" fill="#c88a30" opacity="0.75"/>
+<rect x="811" y="532" width="5" height="6" fill="#c88a30" opacity="0.64"/>
+<rect x="850" y="462" width="77" height="218" fill="#cdbfa3" stroke="#a9967a" stroke-opacity="0.6" stroke-width="1"/>
+<rect x="868" y="479" width="5" height="6" fill="#c88a30" opacity="0.59"/>
+<rect x="933" y="418" width="47" height="262" fill="#cdbfa3" stroke="#a9967a" stroke-opacity="0.6" stroke-width="1"/>
+<rect x="949" y="519" width="5" height="6" fill="#c88a30" opacity="0.78"/>
+<rect x="989" y="469" width="51" height="211" fill="#cdbfa3" stroke="#a9967a" stroke-opacity="0.6" stroke-width="1"/>
+<rect x="1004" y="530" width="5" height="6" fill="#c88a30" opacity="0.49"/>
+<rect x="1043" y="399" width="52" height="281" fill="#cdbfa3" stroke="#a9967a" stroke-opacity="0.6" stroke-width="1"/>
+<rect x="1064" y="481" width="5" height="6" fill="#c88a30" opacity="0.65"/>
+<rect x="1098" y="399" width="66" height="281" fill="#cdbfa3" stroke="#a9967a" stroke-opacity="0.6" stroke-width="1"/>
+<rect x="1132" y="440" width="5" height="6" fill="#c88a30" opacity="0.51"/>
+<rect x="1172" y="400" width="87" height="280" fill="#cdbfa3" stroke="#a9967a" stroke-opacity="0.6" stroke-width="1"/>
+<rect x="1186" y="454" width="5" height="6" fill="#c88a30" opacity="0.64"/>
+<rect x="1206" y="440" width="5" height="6" fill="#c88a30" opacity="0.58"/>
+<rect x="1220" y="487" width="5" height="6" fill="#c88a30" opacity="0.47"/>
+</g>
+<line x1="360" y1="452" x2="864" y2="452" stroke="#c8963f" stroke-width="2.4" stroke-opacity="0.75" stroke-dasharray="10 7" stroke-linecap="round"/>
+<circle cx="864" cy="452" r="7" fill="#fdf7ea" stroke="#9a6a28" stroke-width="1.6"/>
+<circle cx="596" cy="452" r="26" fill="#fdf7ea" stroke="#a86a24" stroke-opacity="0.9" stroke-width="2"/>
+<line x1="585" y1="452" x2="607" y2="452" stroke="#a86a24" stroke-width="3" stroke-linecap="round"/>
+<ellipse cx="550" cy="292" rx="150" ry="120" fill="url(#heart)" filter="url(#softbig)"/>
+<g filter="url(#lift)"><rect x="452" y="232" width="196" height="120" rx="12" fill="url(#panel)" stroke="#9a6a28" stroke-opacity="0.6" stroke-width="1.4"/></g>
+<line x1="482" y1="262" x2="482" y2="322" stroke="#9a6a28" stroke-opacity="0.7" stroke-width="2"/>
+<circle cx="482" cy="262" r="6" fill="none" stroke="#b07d33" stroke-width="2"/>
+<circle cx="482" cy="322" r="6" fill="none" stroke="#b07d33" stroke-width="2"/>
+<path d="M482,282 q0,20 34,20" fill="none" stroke="#9a6a28" stroke-opacity="0.7" stroke-width="2"/>
+<circle cx="522" cy="302" r="6" fill="url(#screen)" stroke="#9a6a28" stroke-opacity="0.6" stroke-width="1"/>
+<rect x="518" y="262" width="95" height="6" rx="3" fill="#b5822f" opacity="0.60"/>
+<rect x="518" y="282" width="74" height="6" rx="3" fill="#b5822f" opacity="0.50"/>
+<path d="M550.0,352 Q586,392 596,422" fill="none" stroke="#9a6a28" stroke-width="1.6" stroke-opacity="0.5" stroke-dasharray="2 6" stroke-linecap="round"/>
+<path d="M416,177 Q423,159 430,150" fill="none" stroke="#c78a33" stroke-width="2.2" stroke-opacity="0.55" stroke-linecap="round"/>
+<circle cx="430" cy="150" r="10.1" fill="url(#halo)" filter="url(#glow)"/>
+<ellipse cx="430" cy="150" rx="6.6" ry="2.4" fill="#e7a94c" opacity="0.30" transform="rotate(-101 430 150)"/>
+<ellipse cx="430" cy="150" rx="6.6" ry="2.4" fill="#e7a94c" opacity="0.30" transform="rotate(-25 430 150)"/>
+<ellipse cx="430" cy="150" rx="4.4" ry="2.6" fill="#c8862e" stroke="#8a5a20" stroke-opacity="0.5" stroke-width="0.6" transform="rotate(-63 430 150)"/>
+<circle cx="428.7" cy="148.7" r="1.8" fill="#fff3d6"/>
+<path d="M703,203 Q696,188 690,180" fill="none" stroke="#c78a33" stroke-width="1.9" stroke-opacity="0.55" stroke-linecap="round"/>
+<circle cx="690" cy="180" r="8.7" fill="url(#halo)" filter="url(#glow)"/>
+<ellipse cx="690" cy="180" rx="5.7" ry="2.1" fill="#e7a94c" opacity="0.30" transform="rotate(-157 690 180)"/>
+<ellipse cx="690" cy="180" rx="5.7" ry="2.1" fill="#e7a94c" opacity="0.30" transform="rotate(-81 690 180)"/>
+<ellipse cx="690" cy="180" rx="3.8" ry="2.3" fill="#c8862e" stroke="#8a5a20" stroke-opacity="0.5" stroke-width="0.6" transform="rotate(-119 690 180)"/>
+<circle cx="688.9" cy="178.9" r="1.5" fill="#fff3d6"/>
+<path d="M526,114 Q537,114 548,120" fill="none" stroke="#c78a33" stroke-width="1.6" stroke-opacity="0.55" stroke-linecap="round"/>
+<circle cx="548" cy="120" r="7.4" fill="url(#halo)" filter="url(#glow)"/>
+<ellipse cx="548" cy="120" rx="3.2" ry="1.9" fill="#c8862e" stroke="#8a5a20" stroke-opacity="0.5" stroke-width="0.6" transform="rotate(16 548 120)"/>
+<circle cx="547.0" cy="119.0" r="1.3" fill="#fff3d6"/>
+<path d="M771,326 Q765,309 760,300" fill="none" stroke="#c78a33" stroke-width="2.0" stroke-opacity="0.55" stroke-linecap="round"/>
+<circle cx="760" cy="300" r="9.2" fill="url(#halo)" filter="url(#glow)"/>
+<ellipse cx="760" cy="300" rx="6.0" ry="2.2" fill="#e7a94c" opacity="0.30" transform="rotate(-150 760 300)"/>
+<ellipse cx="760" cy="300" rx="6.0" ry="2.2" fill="#e7a94c" opacity="0.30" transform="rotate(-74 760 300)"/>
+<ellipse cx="760" cy="300" rx="4.0" ry="2.4" fill="#c8862e" stroke="#8a5a20" stroke-opacity="0.5" stroke-width="0.6" transform="rotate(-112 760 300)"/>
+<circle cx="758.8" cy="298.8" r="1.6" fill="#fff3d6"/>
+<path d="M354,277 Q357,285 360,300" fill="none" stroke="#c78a33" stroke-width="1.7" stroke-opacity="0.55" stroke-linecap="round"/>
+<circle cx="360" cy="300" r="7.8" fill="url(#halo)" filter="url(#glow)"/>
+<ellipse cx="360" cy="300" rx="3.4" ry="2.0" fill="#c8862e" stroke="#8a5a20" stroke-opacity="0.5" stroke-width="0.6" transform="rotate(76 360 300)"/>
+<circle cx="359.0" cy="299.0" r="1.4" fill="#fff3d6"/>
+<path d="M617,308 Q622,314 628,326" fill="none" stroke="#c78a33" stroke-width="1.5" stroke-opacity="0.55" stroke-linecap="round"/>
+<circle cx="628" cy="326" r="6.9" fill="url(#halo)" filter="url(#glow)"/>
+<ellipse cx="628" cy="326" rx="3.0" ry="1.8" fill="#c8862e" stroke="#8a5a20" stroke-opacity="0.5" stroke-width="0.6" transform="rotate(57 628 326)"/>
+<circle cx="627.1" cy="325.1" r="1.2" fill="#fff3d6"/>
+<g>
+<circle cx="614" cy="260" r="1.8" fill="#d59a44" opacity="0.30"/>
+<circle cx="441" cy="310" r="1.5" fill="#d59a44" opacity="0.31"/>
+<circle cx="526" cy="179" r="1.2" fill="#d59a44" opacity="0.39"/>
+<circle cx="1014" cy="308" r="1.6" fill="#d59a44" opacity="0.30"/>
+<circle cx="554" cy="112" r="1.7" fill="#d59a44" opacity="0.29"/>
+<circle cx="412" cy="413" r="1.3" fill="#d59a44" opacity="0.49"/>
+<circle cx="738" cy="334" r="1.6" fill="#d59a44" opacity="0.25"/>
+<circle cx="833" cy="153" r="1.4" fill="#d59a44" opacity="0.24"/>
+<circle cx="178" cy="192" r="1.0" fill="#d59a44" opacity="0.32"/>
+<circle cx="970" cy="419" r="1.4" fill="#d59a44" opacity="0.23"/>
+<circle cx="466" cy="83" r="1.2" fill="#d59a44" opacity="0.39"/>
+<circle cx="737" cy="71" r="1.5" fill="#d59a44" opacity="0.33"/>
+<circle cx="518" cy="109" r="1.4" fill="#d59a44" opacity="0.23"/>
+<circle cx="806" cy="294" r="1.6" fill="#d59a44" opacity="0.32"/>
+</g>
+<rect width="1200" height="675" fill="url(#vig)"/>
+<rect width="1200" height="675" filter="url(#grain)" opacity="0.04"/>
+<text x="60" y="622" font-family="Mo" font-size="12" letter-spacing="3" fill="#9a6a2c" fill-opacity="0.8">FIELD NOTES</text>
+<text x="1140" y="622" text-anchor="end" font-family="Mo" font-size="12" letter-spacing="2" fill="#9a6a2c" fill-opacity="0.55">05 / 06</text>
+</svg>

--- a/beta/public/images/blog/bots-die-nachts-arbeiten.svg
+++ b/beta/public/images/blog/bots-die-nachts-arbeiten.svg
@@ -1,0 +1,161 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 675" width="1200" height="675" role="img" aria-label="Konzept: autonome Bots wie Gluehwuermchen arbeiten nachts ueber einer schlafenden Stadt, oeffnen einen Pull-Request und werden von einer harten Grenze vor dem master-Zweig gestoppt">
+<defs>
+<style>@font-face{font-family:'Mo';src:url(data:font/woff2;base64,d09GMgABAAAAAA7QAA8AAAAAHEwAAA53AAGzMwAAAAAAAAAAAAAAAAAAAAAAAAAAGigbIBwqBmA/U1RBVEgAgX4RCAqsLKJ4ATYCJAOCTguBKgAEIAVmByAb5RWjolZyVsaI/uKAJ0MfBYTACKR2WmgcqlNCrcK+9m3czlmg3OwcHiCxvo6QZPbncdv/GWET8qJtEERBQImSHOxSEy4D5oysF+n7WcHPCHmA7t3721fDDjigCbQtoDzwkMOAozGBw67/AcA5+31rZVXPhOpPB4AUsDtw9+LTsEznE561Gxt1gDZhjaQWB8+J0MAycHtU/O9aafMPyBVQIQrZs301proS/yazu8nm/l7miHgKQG6riFzVTAFIWJa1FfKUqxCyklRf5gzEKs6tRLzvreZMHlPkAjmAW1N4Du46AgGgyKk1jwChGpTK4D5GrWGMkYPXe9kCO5Ug5nNhDHkEAGAdmFjlMxWUeFcn3hdnxmBrLQA3QZrmkxSAd/QqCCC0mIfYkT5xVvASyK94+l74Tq/FLLxheEgIG/nf/d9CMOZjFN8MeDUvC5TJMbV9Hh6AjXdWVXaoD8xUE/+FsQk5KkEN+IxnJye9uSdiRRhSOCO4ilwNdTXBxgh8/TFrlBEoUEZFy8LKLSaJNWvJnc4urh6+fv4NG9fXAZRRqlUPa+5BY3SaU0pzLwCx4viQUqUOeQCcbOwYK62ceZuJByicVqLMx0aiKBElypSrUKmKnEI1FbVadTS0dPQMGhiZEIiIBAAAnsJV3v0gZ0uQ3wOAFQMcgOL1ivAhjlwQn/HSiTz8pMi5AEJMxSRQY3men2qBU0UMz7qKfQw4lnx6r0ogy88vKcwvKqyWFhULrmfPlRZJpaJ8gbR4S74uT5YnLcovqC7aIi6xLltziwTloi0iSRG3qN4qLdosXnps06qLBJtyRV9NgeBbz0JBhbaQL68Qt2MP/nIEuYLLlsmWZ9QE8shKLuO9ttiCZy/Fz1CY+dyIS0z7uftJACYXe9/Y/iedxprdSK/bUKx8ZeOtFAKsebAp5io0RXQV2J5VenvFaaPzm0zOCUOJu7Am0EPN6KkAoQTTowa89RHWJCGIR7rzTQwHZt748VxHozbUqbvVQRbmUjmn67cgK3mmMunc5v4tfnHrUKiD32TpDJ8HdRnpTLGoIACnTiHpiLvY5wJ+9NbB0chacSv6Lxehu16fy2+ZCD92Y3/olTmCVH7KSEFbvUV4F4nJwtURVqcj5xxlmMBMHpVBOoVkGomkpBI6wLdU4HbEmhqarA39ve9+0juOO9mPJooBQM+h9MK7k1g6QtKazfdEvK41/ZOHjJwR6uhi7jdUwZnDq3lnzEa+JmNzztm1jpGleR+Gh19qljughLpWO3nkE0VeMqfscHpK1zDYUssByGubUJhiTdUnn/TL62V+5hePkNMus4fMMLVm+U3ui2IL1MHVOl9JYHiI4soOpnVLBRKxXDU5xywqC+NHmqC8iUmKM9S9pZt1h7qXwgJHdDnswU3Q8hAimT+AvjmKagdZvZWidvQCZyj5LGQpqe+LtAT/QOWDnTsvwf9zuHzm9f0eCX+WgTHlWgXswYnnFhreUDOYetavvyVd/ndO0Vd48OiEWcj+Sm+hmP25PRp90SADQaHPzzdHf2gVGBiyqjHSVzBJR+l1pQDVWFPU1obCB4Yzj0mdeYh1nqQSrTbJ+jRnXkKFOHZTqrVZWgRcb72sciG+biu29/Ieg3tdfM0ISQqtJf7f/v6w/d+W/YwjGvOf9GEt/aNJ6jeHMuZv3t7uePVMwz2yjiOuI14iqaSDUAotbndJ0pqixMHF/R8xEP2BzpG4cuUNzcW42HRfEiZz7dXwIiKf4I/8dfsQd45FzvZpTG3B6UMxMHH5PH7iL7Qasj3U2swLBlkvLmTsQ9zzrIkqdlFxXDnPY2iaGNRSJoRMhzFK5U/enLOSo5Mf3nvmyeFun1c10qd2JcTwxwNs9snZuX62VuUPVetznGmVJtTA7RmcPCZxXCRoM1pCTeg4PIe8lkaj14LmoE6SnM3YL5+atl8+yybbDixtGm0RSsPxiNkS9lTv5Vqq94Q9FmcyKcasQDZz6CCw2au4tTi6YGoKnb/WzDUnIgNTh48cmVobiACbvQmzn0Xj0S+6MPRk74ofs7CNjtN6UElCM3HvZUvTzstn2YS7x+LtE3syQqk7mmgyRTzKvVyLak/UYzEEG1RtO6+J/91P86+cf7k+Fq4Fe5bJ3HzczRkmy7TK/q1A45tLbsZ3Lb4BkEnIfpt1jECJXF6SSiCEcPJN5s251SNw5KMZw/jQV49nmWzDH/33yy+HnixzwbXHYxDGDsnz5pjs/mMDSnzg/iwzl3dIDmR2qWDt4+OYresnx4NagmeS9svnFghZY5y0MHePRMIUdlXvaW2t3ht2m3zpRh/IPTk3YLNvolGDrcPnI5TPhPZvHFjAMZ/LHfPiBVie20czy+Fd3sf3WlS/qoObB8k5I38xE/smuvV14YA6biP5pE3oLX6GkT5UtubRnFYytR9FPA5nxI32g1ESmnb4R4SBjLBHQyG5Xu/dWlZZ8SGuiW+mNrJ6ZbDRbmYH9RTVb7X35royQlbuccvrPRGnofxpqswjY7b02WqbbWYHM6oFYuotnIffmgK1ZGLP8UvPM8+noy2hEKm0K5cyPeDX0ePc/cdvfSTnuMFI5HHWfWpBxMuBLADJhiX7Ke1W7An6R3se7Og5ZadapuvBzke7e84oWwZ4FW9d2nVxyLPrjUsrQM8cu2MJv31+B6dh+KxQH6usc6l9NGKkN1f67G6L6cX70zliNMGxHYNTve/K/pNWIPqkoorPJnKknWSsRE4ZA1WVnlrNxaWZs8rlSggX1vh3bHz0ecF8OIsVB9d+8JfWkL1e43IyaZB/kijmDQ+2cOEBt86vqUo57VVpnxYshWjUa1vB2LY86kO2lhpb8zUp4W2k2UDFBzguPkAZkO3elPAaB9OqhYJCjv/wpNpX+sPaQQXOhgXzz99a5d9RFav3aavSdmdVyq/RucMDXEt4EHSFoRGvdQVj6/KQj/IPumzLmW37BZhO+hs89U9kcjaSM+z3PoUwHAnYHFEErzYEgih0DbqmNKe84aMn0CMIlBdbWuQO//Up4W1PO4Jhi5VRJXQN3gG3dToUtkz1uT3mtGEHpr93mtL9GiTyNbdBc05V1FejIcNt8Xi0DXqyWHXyuX/4t6ssUb2StSWxI2KkzK5wBNmBRq9dufYrKn3yTnQnhtHT0VXVnfXfrG1CLhkVCNPAZvFLxM6JFz98u77v+j/6R48B6a7tZYayVbSPQojaqNyFPkSglEV4sycfY/VptHqv0F1wvDNQ77Kk+jowDrxZtulvVV0cY98z5XsbcPcHHz7rgjC1S+WgG1WsOYkdyBK2q9wVCo/OAepCauTZsCRyiMLTlpPYttIyGKPoAY4joibPArHTr4oS87c7uCZHrCeiXaUoQLhXTEXuIPbdn3f6W/5of2srjJZf41FXpdzuypRXDbmn47z79xHkDlUTNyfXVHc7MR/96jltL1TigUwa+m8FsOjWIy+s3YpezD1+Ntfn9VhGwyPV0XtqS+ZfRNBY6O/WmmldSjhBmppsrvKqLa23nR0WMUqHWlMXyKjcnrTGEF5NCVsKglXW1YodF57yR3NRRmmr1Ro9bZVA/+5t7OxocHeN9sZ9SYYUwC2sTp8wth0YXnDRrhh2uGqGwiXW2lit09/UqL3HaQ8E3b/DUiQUQP/if+WyyhPQa0+g1xHkFMZah9qS2BkxBi3OAB2wYxl9ICtxZUj443sxd/69t+QwB1YH/Brf3ZHx+INvC66/eMgfWZ4FjI9I7iK6jnniyBM9d/If0l2nvCbeF46cjhw7L+oq3/VYLnfR3Wfczb2Ov76zEeI4Nk2iS5aeaQTzvVv+i/HNst2TkYmM7fKp6RYTbCQ6zrKZngK38UwkoSf9ir2pjEDI1esCfkImhfD/BnaK70Edis9iSjJrxB9i0Ic0C3Ojg6b8e2+ukv/+gzbERAoCGWFh/5HlaarfYOQcxsoo9lKKnxh/rWv7MRjkkunlMUEqLRS6sMmlDm39sl57XnCnxozN8tdcSpPf7PH6GscywvzYfFe/v1djTNo8cZoWy5j83v6oz90+rYOD53DR5Hvcmwxmzsl8J+gAlcTfp7NnUEa4HLU7/HEc0lcGPQptTVgp5DQnLGF1qXD9f9Onpb4+p3k0EHCMjTigTkJPBK3H96Z3nu2aGfLEmlIqY+ilTO7dF9tsCY/mENGz4dIRuspA9tssI1TUOTFmDyTIZDqG6KS3PqRQB3Q6RShQAw+N2d+efC7K7scfRj2hjtMdZ+26hAW1hJzUulv9kZaeUPGGh1DYYzalOvRNTZ16Y8rsocIvbggXsz0Rv7t1QksmyIzL64whOkYjpzfj8nMWn9li8NhsVq/NAHmgek3fFR/Xtxo3W23YUzdm3E6umqIpmnnO75dWluCHixsvNi4tTNiuheHRDXyOpmeF+X9iAzHY8G+0PgrdoxEfPqHsJIoSKH2yByITJ5afEAxij8QJKAC/zGOLnj8n4kRE4vqt4aqernQXQ2mwPuXvP4AYkwtxdVuUXJp8C5SwnNCPJK3ESYldMTVR7dHapDjEmKL+0pQgRmUQ+9l7wS+nwbWPcO3dC1sBYDsAz8lfBsX6jzy9ADvs9Dau/8pT8J4gGoBXL6aPrQ/xXcqahxLJQiLxZ8n3AMSu/gX4RY869bLErYaidWdtu8T+Wx6f/yUBwGfpa1Jws1+l//9l/H+Od4KgAsK891bWuzHDS1cT/rtPkBynmgTxKz1mwvYrsKCIZaknDXagSYmhB/RElm+voAK5XW1dAVRyBT0pgYwALJH51IQDKoiexo4RWwZKwGQFokUSix1pYgE2ghEaKJ5HdhbWm7upfAD4nn6c8CuM0ILI0EUwWjHg6gQQAHDypxqDihBOmp/OEzCiAXk+8IgBXowAKCIGeex2rXiLes+4Xv1mjeg0JWVXg9ZrwAzKjE4jonW3uHGjEB57Tzp5fY1OBoQT) format('woff2');}</style>
+<radialGradient id="ground" cx="60%" cy="34%" r="80%">
+  <stop offset="0%" stop-color="#1c1610"/><stop offset="55%" stop-color="#120e0a"/>
+  <stop offset="100%" stop-color="#090705"/>
+</radialGradient>
+<radialGradient id="coreglow" cx="50%" cy="50%" r="50%">
+  <stop offset="0%" stop-color="#f5bd62" stop-opacity="0.52"/>
+  <stop offset="45%" stop-color="#c8863c" stop-opacity="0.20"/>
+  <stop offset="100%" stop-color="#c8863c" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="heart" cx="50%" cy="50%" r="50%">
+  <stop offset="0%" stop-color="#ffdf99" stop-opacity="0.55"/>
+  <stop offset="60%" stop-color="#f0ab4c" stop-opacity="0.12"/>
+  <stop offset="100%" stop-color="#f0ab4c" stop-opacity="0"/>
+</radialGradient>
+<linearGradient id="cell" x1="0" y1="0" x2="0" y2="1">
+  <stop offset="0%" stop-color="#eab866"/><stop offset="52%" stop-color="#b07e40"/>
+  <stop offset="100%" stop-color="#5f4223"/>
+</linearGradient>
+<radialGradient id="hot" cx="50%" cy="42%" r="60%">
+  <stop offset="0%" stop-color="#ffe0a0"/><stop offset="55%" stop-color="#e2a24a"/>
+  <stop offset="100%" stop-color="#7a5327"/>
+</radialGradient>
+<radialGradient id="screen" cx="50%" cy="38%" r="75%">
+  <stop offset="0%" stop-color="#ffdf9c"/><stop offset="60%" stop-color="#e0a24c"/>
+  <stop offset="100%" stop-color="#9c6e34"/>
+</radialGradient>
+<linearGradient id="panel" x1="0" y1="0" x2="0" y2="1">
+  <stop offset="0%" stop-color="#2a2015" stop-opacity="0.92"/>
+  <stop offset="100%" stop-color="#140f0a" stop-opacity="0.92"/>
+</linearGradient>
+<radialGradient id="vig" cx="50%" cy="48%" r="62%">
+  <stop offset="60%" stop-color="#000" stop-opacity="0"/>
+  <stop offset="100%" stop-color="#050403" stop-opacity="0.74"/>
+</radialGradient>
+<filter id="glow" x="-120%" y="-120%" width="340%" height="340%"><feGaussianBlur stdDeviation="7"/></filter>
+<filter id="glowbig" x="-150%" y="-150%" width="400%" height="400%"><feGaussianBlur stdDeviation="13"/></filter>
+<filter id="softbig" x="-60%" y="-60%" width="220%" height="220%"><feGaussianBlur stdDeviation="26"/></filter>
+<filter id="grain"><feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="2" stitchTiles="stitch"/>
+  <feColorMatrix type="matrix" values="0 0 0 0 0.9  0 0 0 0 0.7  0 0 0 0 0.4  0 0 0 0.5 0"/></filter>
+</defs>
+<rect width="1200" height="675" fill="url(#ground)"/>
+<ellipse cx="1046" cy="112" rx="120" ry="120" fill="url(#coreglow)" filter="url(#softbig)"/>
+<circle cx="1046" cy="112" r="46" fill="#f4d9a0" opacity="0.92"/>
+<circle cx="1066" cy="102" r="44" fill="#100c09"/>
+<circle cx="565" cy="137" r="0.7" fill="#ffe9c4" opacity="0.55"/>
+<circle cx="67" cy="171" r="1.4" fill="#ffe9c4" opacity="0.23"/>
+<circle cx="664" cy="200" r="0.6" fill="#ffe9c4" opacity="0.35"/>
+<circle cx="827" cy="158" r="1.3" fill="#ffe9c4" opacity="0.26"/>
+<circle cx="319" cy="69" r="1.1" fill="#ffe9c4" opacity="0.57"/>
+<circle cx="704" cy="241" r="0.9" fill="#ffe9c4" opacity="0.50"/>
+<circle cx="171" cy="116" r="1.2" fill="#ffe9c4" opacity="0.49"/>
+<circle cx="520" cy="63" r="0.8" fill="#ffe9c4" opacity="0.28"/>
+<circle cx="366" cy="250" r="0.8" fill="#ffe9c4" opacity="0.55"/>
+<circle cx="1019" cy="54" r="0.9" fill="#ffe9c4" opacity="0.40"/>
+<circle cx="86" cy="150" r="1.4" fill="#ffe9c4" opacity="0.24"/>
+<circle cx="711" cy="72" r="1.1" fill="#ffe9c4" opacity="0.56"/>
+<circle cx="281" cy="42" r="0.7" fill="#ffe9c4" opacity="0.42"/>
+<circle cx="79" cy="62" r="1.0" fill="#ffe9c4" opacity="0.57"/>
+<circle cx="518" cy="144" r="1.2" fill="#ffe9c4" opacity="0.24"/>
+<circle cx="692" cy="85" r="1.1" fill="#ffe9c4" opacity="0.58"/>
+<g>
+<rect x="-10" y="445" width="48" height="235" fill="#0c0906" stroke="#3a2c1a" stroke-opacity="0.5" stroke-width="1"/>
+<rect x="14" y="470" width="5" height="6" fill="#f4c983" opacity="0.70"/>
+<rect x="48" y="438" width="57" height="242" fill="#0c0906" stroke="#3a2c1a" stroke-opacity="0.5" stroke-width="1"/>
+<rect x="77" y="523" width="5" height="6" fill="#f4c983" opacity="0.41"/>
+<rect x="114" y="457" width="73" height="223" fill="#0c0906" stroke="#3a2c1a" stroke-opacity="0.5" stroke-width="1"/>
+<rect x="123" y="529" width="5" height="6" fill="#f4c983" opacity="0.45"/>
+<rect x="190" y="472" width="66" height="208" fill="#0c0906" stroke="#3a2c1a" stroke-opacity="0.5" stroke-width="1"/>
+<rect x="202" y="522" width="5" height="6" fill="#f4c983" opacity="0.60"/>
+<rect x="263" y="481" width="79" height="199" fill="#0c0906" stroke="#3a2c1a" stroke-opacity="0.5" stroke-width="1"/>
+<rect x="313" y="515" width="5" height="6" fill="#f4c983" opacity="0.68"/>
+<rect x="346" y="490" width="77" height="190" fill="#0c0906" stroke="#3a2c1a" stroke-opacity="0.5" stroke-width="1"/>
+<rect x="401" y="513" width="5" height="6" fill="#f4c983" opacity="0.69"/>
+<rect x="430" y="503" width="47" height="177" fill="#0c0906" stroke="#3a2c1a" stroke-opacity="0.5" stroke-width="1"/>
+<rect x="486" y="493" width="62" height="187" fill="#0c0906" stroke="#3a2c1a" stroke-opacity="0.5" stroke-width="1"/>
+<rect x="517" y="511" width="5" height="6" fill="#f4c983" opacity="0.50"/>
+<rect x="556" y="457" width="49" height="223" fill="#0c0906" stroke="#3a2c1a" stroke-opacity="0.5" stroke-width="1"/>
+<rect x="583" y="526" width="5" height="6" fill="#f4c983" opacity="0.65"/>
+<rect x="609" y="419" width="79" height="261" fill="#0c0906" stroke="#3a2c1a" stroke-opacity="0.5" stroke-width="1"/>
+<rect x="667" y="487" width="5" height="6" fill="#f4c983" opacity="0.27"/>
+<rect x="621" y="519" width="5" height="6" fill="#f4c983" opacity="0.26"/>
+<rect x="693" y="453" width="54" height="227" fill="#0c0906" stroke="#3a2c1a" stroke-opacity="0.5" stroke-width="1"/>
+<rect x="753" y="447" width="70" height="233" fill="#0c0906" stroke="#3a2c1a" stroke-opacity="0.5" stroke-width="1"/>
+<rect x="829" y="435" width="69" height="245" fill="#0c0906" stroke="#3a2c1a" stroke-opacity="0.5" stroke-width="1"/>
+<rect x="839" y="505" width="5" height="6" fill="#f4c983" opacity="0.65"/>
+<rect x="866" y="532" width="5" height="6" fill="#f4c983" opacity="0.52"/>
+<rect x="904" y="462" width="77" height="218" fill="#0c0906" stroke="#3a2c1a" stroke-opacity="0.5" stroke-width="1"/>
+<rect x="922" y="479" width="5" height="6" fill="#f4c983" opacity="0.46"/>
+<rect x="988" y="418" width="47" height="262" fill="#0c0906" stroke="#3a2c1a" stroke-opacity="0.5" stroke-width="1"/>
+<rect x="1004" y="519" width="5" height="6" fill="#f4c983" opacity="0.68"/>
+<rect x="1043" y="469" width="51" height="211" fill="#0c0906" stroke="#3a2c1a" stroke-opacity="0.5" stroke-width="1"/>
+<rect x="1058" y="530" width="5" height="6" fill="#f4c983" opacity="0.35"/>
+<rect x="1097" y="399" width="52" height="281" fill="#0c0906" stroke="#3a2c1a" stroke-opacity="0.5" stroke-width="1"/>
+<rect x="1119" y="481" width="5" height="6" fill="#f4c983" opacity="0.54"/>
+<rect x="1152" y="399" width="66" height="281" fill="#0c0906" stroke="#3a2c1a" stroke-opacity="0.5" stroke-width="1"/>
+<rect x="1187" y="440" width="5" height="6" fill="#f4c983" opacity="0.37"/>
+</g>
+<line x1="360" y1="452" x2="864" y2="452" stroke="#e8b968" stroke-width="2.4" stroke-opacity="0.65" stroke-dasharray="10 7" stroke-linecap="round"/>
+<circle cx="864" cy="452" r="7" fill="#140f0a" stroke="#f0c479" stroke-width="1.6"/>
+<circle cx="596" cy="452" r="26" fill="#1a1310" stroke="#ffbf7a" stroke-opacity="0.85" stroke-width="2"/>
+<line x1="585" y1="452" x2="607" y2="452" stroke="#ffbf7a" stroke-width="3" stroke-linecap="round"/>
+<ellipse cx="550" cy="292" rx="150" ry="120" fill="url(#heart)" filter="url(#softbig)"/>
+<rect x="452" y="232" width="196" height="120" rx="12" fill="url(#panel)" stroke="#ffdca0" stroke-opacity="0.55" stroke-width="1.5"/>
+<line x1="482" y1="262" x2="482" y2="322" stroke="#ffdca0" stroke-opacity="0.6" stroke-width="2"/>
+<circle cx="482" cy="262" r="6" fill="none" stroke="#ffe7b0" stroke-width="2"/>
+<circle cx="482" cy="322" r="6" fill="none" stroke="#ffe7b0" stroke-width="2"/>
+<path d="M482,282 q0,20 34,20" fill="none" stroke="#ffdca0" stroke-opacity="0.6" stroke-width="2"/>
+<circle cx="522" cy="302" r="6" fill="url(#screen)"/>
+<rect x="518" y="262" width="95" height="6" rx="3" fill="#e0a24c" opacity="0.50"/>
+<rect x="518" y="282" width="74" height="6" rx="3" fill="#e0a24c" opacity="0.40"/>
+<path d="M550.0,352 Q586,392 596,422" fill="none" stroke="#ffd98f" stroke-width="1.6" stroke-opacity="0.4" stroke-dasharray="2 6" stroke-linecap="round"/>
+<path d="M455,132 Q443,137 430,150" fill="none" stroke="#ffd98f" stroke-width="2.2" stroke-opacity="0.40" stroke-linecap="round"/>
+<circle cx="430" cy="150" r="10.1" fill="#ffcf7a" opacity="0.50" filter="url(#glow)"/>
+<ellipse cx="430" cy="150" rx="6.6" ry="2.4" fill="#ffe9c4" opacity="0.18" transform="rotate(107 430 150)"/>
+<ellipse cx="430" cy="150" rx="6.6" ry="2.4" fill="#ffe9c4" opacity="0.18" transform="rotate(183 430 150)"/>
+<ellipse cx="430" cy="150" rx="4.4" ry="2.6" fill="#fff3d6" transform="rotate(145 430 150)"/>
+<path d="M714,169 Q702,171 690,180" fill="none" stroke="#ffd98f" stroke-width="1.9" stroke-opacity="0.40" stroke-linecap="round"/>
+<circle cx="690" cy="180" r="8.7" fill="#ffcf7a" opacity="0.50" filter="url(#glow)"/>
+<ellipse cx="690" cy="180" rx="5.7" ry="2.1" fill="#ffe9c4" opacity="0.18" transform="rotate(117 690 180)"/>
+<ellipse cx="690" cy="180" rx="5.7" ry="2.1" fill="#ffe9c4" opacity="0.18" transform="rotate(193 690 180)"/>
+<ellipse cx="690" cy="180" rx="3.8" ry="2.3" fill="#fff3d6" transform="rotate(155 690 180)"/>
+<path d="M564,104 Q556,109 548,120" fill="none" stroke="#ffd98f" stroke-width="1.6" stroke-opacity="0.40" stroke-linecap="round"/>
+<circle cx="548" cy="120" r="7.4" fill="#ffcf7a" opacity="0.50" filter="url(#glow)"/>
+<ellipse cx="548" cy="120" rx="3.2" ry="1.9" fill="#fff3d6" transform="rotate(136 548 120)"/>
+<path d="M785,287 Q772,289 760,300" fill="none" stroke="#ffd98f" stroke-width="2.0" stroke-opacity="0.40" stroke-linecap="round"/>
+<circle cx="760" cy="300" r="9.2" fill="#ffcf7a" opacity="0.50" filter="url(#glow)"/>
+<ellipse cx="760" cy="300" rx="6.0" ry="2.2" fill="#ffe9c4" opacity="0.18" transform="rotate(113 760 300)"/>
+<ellipse cx="760" cy="300" rx="6.0" ry="2.2" fill="#ffe9c4" opacity="0.18" transform="rotate(189 760 300)"/>
+<ellipse cx="760" cy="300" rx="4.0" ry="2.4" fill="#fff3d6" transform="rotate(151 760 300)"/>
+<path d="M383,295 Q372,294 360,300" fill="none" stroke="#ffd98f" stroke-width="1.7" stroke-opacity="0.40" stroke-linecap="round"/>
+<circle cx="360" cy="300" r="7.8" fill="#ffcf7a" opacity="0.50" filter="url(#glow)"/>
+<ellipse cx="360" cy="300" rx="3.4" ry="2.0" fill="#fff3d6" transform="rotate(168 360 300)"/>
+<path d="M645,338 Q637,329 628,326" fill="none" stroke="#ffd98f" stroke-width="1.5" stroke-opacity="0.40" stroke-linecap="round"/>
+<circle cx="628" cy="326" r="6.9" fill="#ffcf7a" opacity="0.50" filter="url(#glow)"/>
+<ellipse cx="628" cy="326" rx="3.0" ry="1.8" fill="#fff3d6" transform="rotate(-146 628 326)"/>
+<g>
+<circle cx="614" cy="260" r="1.9" fill="#f4c983" opacity="0.26" filter="url(#glow)"/>
+<circle cx="441" cy="310" r="1.4" fill="#f4c983" opacity="0.28" filter="url(#glow)"/>
+<circle cx="526" cy="179" r="1.0" fill="#f4c983" opacity="0.37" filter="url(#glow)"/>
+<circle cx="1014" cy="308" r="1.6" fill="#f4c983" opacity="0.27" filter="url(#glow)"/>
+<circle cx="554" cy="112" r="1.7" fill="#f4c983" opacity="0.25" filter="url(#glow)"/>
+<circle cx="412" cy="413" r="1.2" fill="#f4c983" opacity="0.49" filter="url(#glow)"/>
+<circle cx="738" cy="334" r="1.6" fill="#f4c983" opacity="0.21" filter="url(#glow)"/>
+<circle cx="833" cy="153" r="1.3" fill="#f4c983" opacity="0.20" filter="url(#glow)"/>
+<circle cx="178" cy="192" r="0.8" fill="#f4c983" opacity="0.28" filter="url(#glow)"/>
+<circle cx="970" cy="419" r="1.3" fill="#f4c983" opacity="0.19" filter="url(#glow)"/>
+<circle cx="466" cy="83" r="1.1" fill="#f4c983" opacity="0.37" filter="url(#glow)"/>
+<circle cx="737" cy="71" r="1.4" fill="#f4c983" opacity="0.30" filter="url(#glow)"/>
+<circle cx="518" cy="109" r="1.3" fill="#f4c983" opacity="0.19" filter="url(#glow)"/>
+<circle cx="806" cy="294" r="1.6" fill="#f4c983" opacity="0.29" filter="url(#glow)"/>
+<circle cx="1077" cy="193" r="1.1" fill="#f4c983" opacity="0.28" filter="url(#glow)"/>
+<circle cx="1033" cy="117" r="1.8" fill="#f4c983" opacity="0.48" filter="url(#glow)"/>
+</g>
+<rect width="1200" height="675" fill="url(#vig)"/>
+<rect width="1200" height="675" filter="url(#grain)" opacity="0.05"/>
+<text x="60" y="622" font-family="Mo" font-size="12" letter-spacing="3" fill="#e8b968" fill-opacity="0.55">FIELD NOTES</text>
+<text x="1140" y="622" text-anchor="end" font-family="Mo" font-size="12" letter-spacing="2" fill="#e8b968" fill-opacity="0.38">05 / 06</text>
+</svg>

--- a/beta/public/images/blog/cockpit-tag-mit-zehn-agenten-light.svg
+++ b/beta/public/images/blog/cockpit-tag-mit-zehn-agenten-light.svg
@@ -1,0 +1,155 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 675" width="1200" height="675" role="img" aria-label="Konzept (hell): ein Cockpit mit zehn Scannern faechert zu allen Quellen und buendelt sie zu einer einzigen naechsten Handlung">
+<defs>
+<style>@font-face{font-family:'Mo';src:url(data:font/woff2;base64,d09GMgABAAAAAA7QAA8AAAAAHEwAAA53AAGzMwAAAAAAAAAAAAAAAAAAAAAAAAAAGigbIBwqBmA/U1RBVEgAgX4RCAqsLKJ4ATYCJAOCTguBKgAEIAVmByAb5RWjolZyVsaI/uKAJ0MfBYTACKR2WmgcqlNCrcK+9m3czlmg3OwcHiCxvo6QZPbncdv/GWET8qJtEERBQImSHOxSEy4D5oysF+n7WcHPCHmA7t3721fDDjigCbQtoDzwkMOAozGBw67/AcA5+31rZVXPhOpPB4AUsDtw9+LTsEznE561Gxt1gDZhjaQWB8+J0MAycHtU/O9aafMPyBVQIQrZs301proS/yazu8nm/l7miHgKQG6riFzVTAFIWJa1FfKUqxCyklRf5gzEKs6tRLzvreZMHlPkAjmAW1N4Du46AgGgyKk1jwChGpTK4D5GrWGMkYPXe9kCO5Ug5nNhDHkEAGAdmFjlMxWUeFcn3hdnxmBrLQA3QZrmkxSAd/QqCCC0mIfYkT5xVvASyK94+l74Tq/FLLxheEgIG/nf/d9CMOZjFN8MeDUvC5TJMbV9Hh6AjXdWVXaoD8xUE/+FsQk5KkEN+IxnJye9uSdiRRhSOCO4ilwNdTXBxgh8/TFrlBEoUEZFy8LKLSaJNWvJnc4urh6+fv4NG9fXAZRRqlUPa+5BY3SaU0pzLwCx4viQUqUOeQCcbOwYK62ceZuJByicVqLMx0aiKBElypSrUKmKnEI1FbVadTS0dPQMGhiZEIiIBAAAnsJV3v0gZ0uQ3wOAFQMcgOL1ivAhjlwQn/HSiTz8pMi5AEJMxSRQY3men2qBU0UMz7qKfQw4lnx6r0ogy88vKcwvKqyWFhULrmfPlRZJpaJ8gbR4S74uT5YnLcovqC7aIi6xLltziwTloi0iSRG3qN4qLdosXnps06qLBJtyRV9NgeBbz0JBhbaQL68Qt2MP/nIEuYLLlsmWZ9QE8shKLuO9ttiCZy/Fz1CY+dyIS0z7uftJACYXe9/Y/iedxprdSK/bUKx8ZeOtFAKsebAp5io0RXQV2J5VenvFaaPzm0zOCUOJu7Am0EPN6KkAoQTTowa89RHWJCGIR7rzTQwHZt748VxHozbUqbvVQRbmUjmn67cgK3mmMunc5v4tfnHrUKiD32TpDJ8HdRnpTLGoIACnTiHpiLvY5wJ+9NbB0chacSv6Lxehu16fy2+ZCD92Y3/olTmCVH7KSEFbvUV4F4nJwtURVqcj5xxlmMBMHpVBOoVkGomkpBI6wLdU4HbEmhqarA39ve9+0juOO9mPJooBQM+h9MK7k1g6QtKazfdEvK41/ZOHjJwR6uhi7jdUwZnDq3lnzEa+JmNzztm1jpGleR+Gh19qljughLpWO3nkE0VeMqfscHpK1zDYUssByGubUJhiTdUnn/TL62V+5hePkNMus4fMMLVm+U3ui2IL1MHVOl9JYHiI4soOpnVLBRKxXDU5xywqC+NHmqC8iUmKM9S9pZt1h7qXwgJHdDnswU3Q8hAimT+AvjmKagdZvZWidvQCZyj5LGQpqe+LtAT/QOWDnTsvwf9zuHzm9f0eCX+WgTHlWgXswYnnFhreUDOYetavvyVd/ndO0Vd48OiEWcj+Sm+hmP25PRp90SADQaHPzzdHf2gVGBiyqjHSVzBJR+l1pQDVWFPU1obCB4Yzj0mdeYh1nqQSrTbJ+jRnXkKFOHZTqrVZWgRcb72sciG+biu29/Ieg3tdfM0ISQqtJf7f/v6w/d+W/YwjGvOf9GEt/aNJ6jeHMuZv3t7uePVMwz2yjiOuI14iqaSDUAotbndJ0pqixMHF/R8xEP2BzpG4cuUNzcW42HRfEiZz7dXwIiKf4I/8dfsQd45FzvZpTG3B6UMxMHH5PH7iL7Qasj3U2swLBlkvLmTsQ9zzrIkqdlFxXDnPY2iaGNRSJoRMhzFK5U/enLOSo5Mf3nvmyeFun1c10qd2JcTwxwNs9snZuX62VuUPVetznGmVJtTA7RmcPCZxXCRoM1pCTeg4PIe8lkaj14LmoE6SnM3YL5+atl8+yybbDixtGm0RSsPxiNkS9lTv5Vqq94Q9FmcyKcasQDZz6CCw2au4tTi6YGoKnb/WzDUnIgNTh48cmVobiACbvQmzn0Xj0S+6MPRk74ofs7CNjtN6UElCM3HvZUvTzstn2YS7x+LtE3syQqk7mmgyRTzKvVyLak/UYzEEG1RtO6+J/91P86+cf7k+Fq4Fe5bJ3HzczRkmy7TK/q1A45tLbsZ3Lb4BkEnIfpt1jECJXF6SSiCEcPJN5s251SNw5KMZw/jQV49nmWzDH/33yy+HnixzwbXHYxDGDsnz5pjs/mMDSnzg/iwzl3dIDmR2qWDt4+OYresnx4NagmeS9svnFghZY5y0MHePRMIUdlXvaW2t3ht2m3zpRh/IPTk3YLNvolGDrcPnI5TPhPZvHFjAMZ/LHfPiBVie20czy+Fd3sf3WlS/qoObB8k5I38xE/smuvV14YA6biP5pE3oLX6GkT5UtubRnFYytR9FPA5nxI32g1ESmnb4R4SBjLBHQyG5Xu/dWlZZ8SGuiW+mNrJ6ZbDRbmYH9RTVb7X35royQlbuccvrPRGnofxpqswjY7b02WqbbWYHM6oFYuotnIffmgK1ZGLP8UvPM8+noy2hEKm0K5cyPeDX0ePc/cdvfSTnuMFI5HHWfWpBxMuBLADJhiX7Ke1W7An6R3se7Og5ZadapuvBzke7e84oWwZ4FW9d2nVxyLPrjUsrQM8cu2MJv31+B6dh+KxQH6usc6l9NGKkN1f67G6L6cX70zliNMGxHYNTve/K/pNWIPqkoorPJnKknWSsRE4ZA1WVnlrNxaWZs8rlSggX1vh3bHz0ecF8OIsVB9d+8JfWkL1e43IyaZB/kijmDQ+2cOEBt86vqUo57VVpnxYshWjUa1vB2LY86kO2lhpb8zUp4W2k2UDFBzguPkAZkO3elPAaB9OqhYJCjv/wpNpX+sPaQQXOhgXzz99a5d9RFav3aavSdmdVyq/RucMDXEt4EHSFoRGvdQVj6/KQj/IPumzLmW37BZhO+hs89U9kcjaSM+z3PoUwHAnYHFEErzYEgih0DbqmNKe84aMn0CMIlBdbWuQO//Up4W1PO4Jhi5VRJXQN3gG3dToUtkz1uT3mtGEHpr93mtL9GiTyNbdBc05V1FejIcNt8Xi0DXqyWHXyuX/4t6ssUb2StSWxI2KkzK5wBNmBRq9dufYrKn3yTnQnhtHT0VXVnfXfrG1CLhkVCNPAZvFLxM6JFz98u77v+j/6R48B6a7tZYayVbSPQojaqNyFPkSglEV4sycfY/VptHqv0F1wvDNQ77Kk+jowDrxZtulvVV0cY98z5XsbcPcHHz7rgjC1S+WgG1WsOYkdyBK2q9wVCo/OAepCauTZsCRyiMLTlpPYttIyGKPoAY4joibPArHTr4oS87c7uCZHrCeiXaUoQLhXTEXuIPbdn3f6W/5of2srjJZf41FXpdzuypRXDbmn47z79xHkDlUTNyfXVHc7MR/96jltL1TigUwa+m8FsOjWIy+s3YpezD1+Ntfn9VhGwyPV0XtqS+ZfRNBY6O/WmmldSjhBmppsrvKqLa23nR0WMUqHWlMXyKjcnrTGEF5NCVsKglXW1YodF57yR3NRRmmr1Ro9bZVA/+5t7OxocHeN9sZ9SYYUwC2sTp8wth0YXnDRrhh2uGqGwiXW2lit09/UqL3HaQ8E3b/DUiQUQP/if+WyyhPQa0+g1xHkFMZah9qS2BkxBi3OAB2wYxl9ICtxZUj443sxd/69t+QwB1YH/Brf3ZHx+INvC66/eMgfWZ4FjI9I7iK6jnniyBM9d/If0l2nvCbeF46cjhw7L+oq3/VYLnfR3Wfczb2Ov76zEeI4Nk2iS5aeaQTzvVv+i/HNst2TkYmM7fKp6RYTbCQ6zrKZngK38UwkoSf9ir2pjEDI1esCfkImhfD/BnaK70Edis9iSjJrxB9i0Ic0C3Ojg6b8e2+ukv/+gzbERAoCGWFh/5HlaarfYOQcxsoo9lKKnxh/rWv7MRjkkunlMUEqLRS6sMmlDm39sl57XnCnxozN8tdcSpPf7PH6GscywvzYfFe/v1djTNo8cZoWy5j83v6oz90+rYOD53DR5Hvcmwxmzsl8J+gAlcTfp7NnUEa4HLU7/HEc0lcGPQptTVgp5DQnLGF1qXD9f9Onpb4+p3k0EHCMjTigTkJPBK3H96Z3nu2aGfLEmlIqY+ilTO7dF9tsCY/mENGz4dIRuspA9tssI1TUOTFmDyTIZDqG6KS3PqRQB3Q6RShQAw+N2d+efC7K7scfRj2hjtMdZ+26hAW1hJzUulv9kZaeUPGGh1DYYzalOvRNTZ16Y8rsocIvbggXsz0Rv7t1QksmyIzL64whOkYjpzfj8nMWn9li8NhsVq/NAHmgek3fFR/Xtxo3W23YUzdm3E6umqIpmnnO75dWluCHixsvNi4tTNiuheHRDXyOpmeF+X9iAzHY8G+0PgrdoxEfPqHsJIoSKH2yByITJ5afEAxij8QJKAC/zGOLnj8n4kRE4vqt4aqernQXQ2mwPuXvP4AYkwtxdVuUXJp8C5SwnNCPJK3ESYldMTVR7dHapDjEmKL+0pQgRmUQ+9l7wS+nwbWPcO3dC1sBYDsAz8lfBsX6jzy9ADvs9Dau/8pT8J4gGoBXL6aPrQ/xXcqahxLJQiLxZ8n3AMSu/gX4RY869bLErYaidWdtu8T+Wx6f/yUBwGfpa1Jws1+l//9l/H+Od4KgAsK891bWuzHDS1cT/rtPkBynmgTxKz1mwvYrsKCIZaknDXagSYmhB/RElm+voAK5XW1dAVRyBT0pgYwALJH51IQDKoiexo4RWwZKwGQFokUSix1pYgE2ghEaKJ5HdhbWm7upfAD4nn6c8CuM0ILI0EUwWjHg6gQQAHDypxqDihBOmp/OEzCiAXk+8IgBXowAKCIGeex2rXiLes+4Xv1mjeg0JWVXg9ZrwAzKjE4jonW3uHGjEB57Tzp5fY1OBoQT) format('woff2');}</style>
+<radialGradient id="ground" cx="46%" cy="48%" r="80%">
+  <stop offset="0%" stop-color="#fdfaf3"/><stop offset="58%" stop-color="#f3ecdb"/><stop offset="100%" stop-color="#e4d9c1"/>
+</radialGradient>
+<radialGradient id="coreglow" cx="50%" cy="50%" r="50%">
+  <stop offset="0%" stop-color="#ffdd93" stop-opacity="0.55"/><stop offset="55%" stop-color="#f2c46a" stop-opacity="0.16"/><stop offset="100%" stop-color="#f0ab4c" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="heart" cx="50%" cy="50%" r="50%">
+  <stop offset="0%" stop-color="#ffe3a0" stop-opacity="0.55"/><stop offset="60%" stop-color="#f0ab4c" stop-opacity="0.12"/><stop offset="100%" stop-color="#f0ab4c" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="halo" cx="50%" cy="50%" r="50%">
+  <stop offset="0%" stop-color="#f6bf5c" stop-opacity="0.7"/><stop offset="100%" stop-color="#f6bf5c" stop-opacity="0"/>
+</radialGradient>
+<linearGradient id="cell" x1="0" y1="0" x2="0" y2="1">
+  <stop offset="0%" stop-color="#f0b957"/><stop offset="55%" stop-color="#d5923c"/><stop offset="100%" stop-color="#b0742c"/>
+</linearGradient>
+<linearGradient id="hot" x1="0" y1="0" x2="0" y2="1">
+  <stop offset="0%" stop-color="#ffe6a6"/><stop offset="50%" stop-color="#f6c065"/><stop offset="100%" stop-color="#dc9d3e"/>
+</linearGradient>
+<linearGradient id="screen" x1="0" y1="0" x2="0" y2="1">
+  <stop offset="0%" stop-color="#ffe7ad"/><stop offset="100%" stop-color="#e6ab52"/>
+</linearGradient>
+<linearGradient id="panel" x1="0" y1="0" x2="0" y2="1">
+  <stop offset="0%" stop-color="#fffaf0"/><stop offset="100%" stop-color="#f4e8d0"/>
+</linearGradient>
+<radialGradient id="vig" cx="50%" cy="46%" r="66%">
+  <stop offset="62%" stop-color="#8a6a34" stop-opacity="0"/><stop offset="100%" stop-color="#8a6a34" stop-opacity="0.16"/>
+</radialGradient>
+<filter id="glow" x="-120%" y="-120%" width="340%" height="340%"><feGaussianBlur stdDeviation="6"/></filter>
+<filter id="glowbig" x="-150%" y="-150%" width="400%" height="400%"><feGaussianBlur stdDeviation="11"/></filter>
+<filter id="softbig" x="-60%" y="-60%" width="220%" height="220%"><feGaussianBlur stdDeviation="24"/></filter>
+<filter id="lift" x="-40%" y="-40%" width="180%" height="200%"><feDropShadow dx="0" dy="6" stdDeviation="11" flood-color="#6e4e24" flood-opacity="0.26"/></filter>
+<filter id="grain"><feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="2" stitchTiles="stitch"/>
+  <feColorMatrix type="matrix" values="0 0 0 0 0.42  0 0 0 0 0.30  0 0 0 0 0.12  0 0 0 0.5 0"/></filter>
+</defs>
+<rect width="1200" height="675" fill="url(#ground)"/>
+<ellipse cx="474" cy="342" rx="300" ry="260" fill="url(#coreglow)" filter="url(#softbig)"/>
+<line x1="316" y1="528" x2="474" y2="342" stroke="#b07a34" stroke-width="1.4" stroke-opacity="0.4"/>
+<circle cx="405" cy="423" r="4.9" fill="url(#halo)" filter="url(#glow)"/>
+<circle cx="405" cy="423" r="1.9" fill="#d59433" stroke="#8a5a20" stroke-opacity="0.4" stroke-width="0.6"/>
+<circle cx="404.6" cy="422.6" r="0.8" fill="#fff3d6"/>
+<line x1="279" y1="495" x2="474" y2="342" stroke="#b07a34" stroke-width="1.4" stroke-opacity="0.4"/>
+<circle cx="377" cy="418" r="4.9" fill="url(#halo)" filter="url(#glow)"/>
+<circle cx="377" cy="418" r="1.9" fill="#d59433" stroke="#8a5a20" stroke-opacity="0.4" stroke-width="0.6"/>
+<circle cx="376.6" cy="417.5" r="0.8" fill="#fff3d6"/>
+<line x1="250" y1="456" x2="474" y2="342" stroke="#b07a34" stroke-width="1.4" stroke-opacity="0.4"/>
+<circle cx="402" cy="379" r="4.9" fill="url(#halo)" filter="url(#glow)"/>
+<circle cx="402" cy="379" r="1.9" fill="#d59433" stroke="#8a5a20" stroke-opacity="0.4" stroke-width="0.6"/>
+<circle cx="401.2" cy="378.2" r="0.8" fill="#fff3d6"/>
+<line x1="230" y1="412" x2="474" y2="342" stroke="#b07a34" stroke-width="1.4" stroke-opacity="0.4"/>
+<circle cx="346" cy="379" r="4.9" fill="url(#halo)" filter="url(#glow)"/>
+<circle cx="346" cy="379" r="1.9" fill="#d59433" stroke="#8a5a20" stroke-opacity="0.4" stroke-width="0.6"/>
+<circle cx="345.2" cy="378.3" r="0.8" fill="#fff3d6"/>
+<line x1="219" y1="366" x2="474" y2="342" stroke="#b07a34" stroke-width="1.4" stroke-opacity="0.4"/>
+<circle cx="382" cy="351" r="4.9" fill="url(#halo)" filter="url(#glow)"/>
+<circle cx="382" cy="351" r="1.9" fill="#d59433" stroke="#8a5a20" stroke-opacity="0.4" stroke-width="0.6"/>
+<circle cx="381.1" cy="350.0" r="0.8" fill="#fff3d6"/>
+<line x1="219" y1="318" x2="474" y2="342" stroke="#b07a34" stroke-width="1.4" stroke-opacity="0.4"/>
+<circle cx="367" cy="332" r="4.9" fill="url(#halo)" filter="url(#glow)"/>
+<circle cx="367" cy="332" r="1.9" fill="#d59433" stroke="#8a5a20" stroke-opacity="0.4" stroke-width="0.6"/>
+<circle cx="365.9" cy="331.4" r="0.8" fill="#fff3d6"/>
+<line x1="230" y1="272" x2="474" y2="342" stroke="#b07a34" stroke-width="1.4" stroke-opacity="0.4"/>
+<circle cx="345" cy="305" r="4.9" fill="url(#halo)" filter="url(#glow)"/>
+<circle cx="345" cy="305" r="1.9" fill="#d59433" stroke="#8a5a20" stroke-opacity="0.4" stroke-width="0.6"/>
+<circle cx="344.0" cy="304.2" r="0.8" fill="#fff3d6"/>
+<line x1="250" y1="228" x2="474" y2="342" stroke="#b07a34" stroke-width="1.4" stroke-opacity="0.4"/>
+<circle cx="391" cy="300" r="4.9" fill="url(#halo)" filter="url(#glow)"/>
+<circle cx="391" cy="300" r="1.9" fill="#d59433" stroke="#8a5a20" stroke-opacity="0.4" stroke-width="0.6"/>
+<circle cx="390.0" cy="299.0" r="0.8" fill="#fff3d6"/>
+<line x1="279" y1="189" x2="474" y2="342" stroke="#b07a34" stroke-width="1.4" stroke-opacity="0.4"/>
+<circle cx="369" cy="260" r="4.9" fill="url(#halo)" filter="url(#glow)"/>
+<circle cx="369" cy="260" r="1.9" fill="#d59433" stroke="#8a5a20" stroke-opacity="0.4" stroke-width="0.6"/>
+<circle cx="368.8" cy="259.2" r="0.8" fill="#fff3d6"/>
+<line x1="316" y1="156" x2="474" y2="342" stroke="#b07a34" stroke-width="1.4" stroke-opacity="0.4"/>
+<circle cx="411" cy="268" r="4.9" fill="url(#halo)" filter="url(#glow)"/>
+<circle cx="411" cy="268" r="1.9" fill="#d59433" stroke="#8a5a20" stroke-opacity="0.4" stroke-width="0.6"/>
+<circle cx="410.7" cy="267.4" r="0.8" fill="#fff3d6"/>
+<g filter="url(#lift)"><circle cx="316.3906623166315" cy="527.9705378511865" r="19" fill="url(#panel)" stroke="#9a6a28" stroke-opacity="0.45" stroke-width="1.3"/></g>
+<rect x="307.3906623166315" y="521.9705378511865" width="18" height="13" rx="2" stroke="#9a6a28" stroke-opacity="0.8" stroke-width="1.6" fill="none"/>
+<path d="M308.3906623166315,523.9705378511865 L316.3906623166315,529.9705378511865 L324.3906623166315,523.9705378511865" stroke="#9a6a28" stroke-opacity="0.8" stroke-width="1.6" fill="none"/>
+<g filter="url(#lift)"><circle cx="279.1749553558527" cy="495.09566212120495" r="19" fill="url(#panel)" stroke="#9a6a28" stroke-opacity="0.45" stroke-width="1.3"/></g>
+<rect x="270.1749553558527" y="487.09566212120495" width="18" height="13" rx="4" stroke="#9a6a28" stroke-opacity="0.8" stroke-width="1.6" fill="none"/>
+<path d="M275.1749553558527,500.09566212120495 l0,4 l5,-4 z" fill="#9a6a28" opacity="0.7" stroke="none"/>
+<g filter="url(#lift)"><circle cx="249.85709278666477" cy="456.0145734340067" r="19" fill="url(#panel)" stroke="#9a6a28" stroke-opacity="0.45" stroke-width="1.3"/></g>
+<rect x="240.85709278666477" y="449.0145734340067" width="18" height="15" rx="2" stroke="#9a6a28" stroke-opacity="0.8" stroke-width="1.6" fill="none"/>
+<line x1="240.85709278666477" y1="454.0145734340067" x2="258.8570927866648" y2="454.0145734340067" stroke="#9a6a28" stroke-opacity="0.8" stroke-width="1.6" fill="none"/>
+<circle cx="244.85709278666477" cy="460.0145734340067" r="1.4" fill="#9a6a28" opacity="0.7"/>
+<circle cx="249.85709278666477" cy="460.0145734340067" r="1.4" fill="#9a6a28" opacity="0.7"/>
+<circle cx="254.85709278666477" cy="460.0145734340067" r="1.4" fill="#9a6a28" opacity="0.7"/>
+<g filter="url(#lift)"><circle cx="229.62556614458063" cy="412.3115463250818" r="19" fill="url(#panel)" stroke="#9a6a28" stroke-opacity="0.45" stroke-width="1.3"/></g>
+<path d="M223.62556614458063,404.3115463250818 L238.62556614458063,412.3115463250818 L223.62556614458063,420.3115463250818 z" stroke="#9a6a28" stroke-opacity="0.8" stroke-width="1.6" fill="none"/>
+<g filter="url(#lift)"><circle cx="219.30052383257055" cy="365.75822010383314" r="19" fill="url(#panel)" stroke="#9a6a28" stroke-opacity="0.45" stroke-width="1.3"/></g>
+<path d="M210.30052383257055,359.75822010383314 l6,0 l2,3 l10,0 l0,9 l-18,0 z" stroke="#9a6a28" stroke-opacity="0.8" stroke-width="1.6" fill="none"/>
+<g filter="url(#lift)"><circle cx="219.30052383257055" cy="318.2417798961669" r="19" fill="url(#panel)" stroke="#9a6a28" stroke-opacity="0.45" stroke-width="1.3"/></g>
+<path d="M212.30052383257055,322.2417798961669 q0,-14 7,-14 q7,0 7,14 z" stroke="#9a6a28" stroke-opacity="0.8" stroke-width="1.6" fill="none"/>
+<circle cx="219.30052383257055" cy="325.2417798961669" r="2" fill="#9a6a28" opacity="0.7"/>
+<g filter="url(#lift)"><circle cx="229.62556614458057" cy="271.6884536749184" r="19" fill="url(#panel)" stroke="#9a6a28" stroke-opacity="0.45" stroke-width="1.3"/></g>
+<path d="M222.62556614458057,262.6884536749184 l10,0 l5,5 l0,13 l-15,0 z" stroke="#9a6a28" stroke-opacity="0.8" stroke-width="1.6" fill="none"/>
+<line x1="225.62556614458057" y1="271.6884536749184" x2="234.62556614458057" y2="271.6884536749184" stroke="#9a6a28" stroke-opacity="0.8" stroke-width="1.6" fill="none"/>
+<line x1="225.62556614458057" y1="275.6884536749184" x2="234.62556614458057" y2="275.6884536749184" stroke="#9a6a28" stroke-opacity="0.8" stroke-width="1.6" fill="none"/>
+<g filter="url(#lift)"><circle cx="249.85709278666474" cy="227.98542656599335" r="19" fill="url(#panel)" stroke="#9a6a28" stroke-opacity="0.45" stroke-width="1.3"/></g>
+<path d="M240.85709278666474,225.98542656599335 l7,-7 l10,0 l0,10 l-7,7 z" stroke="#9a6a28" stroke-opacity="0.8" stroke-width="1.6" fill="none"/>
+<circle cx="251.85709278666474" cy="225.98542656599335" r="2" fill="#9a6a28" opacity="0.7"/>
+<g filter="url(#lift)"><circle cx="279.1749553558527" cy="188.904337878795" r="19" fill="url(#panel)" stroke="#9a6a28" stroke-opacity="0.45" stroke-width="1.3"/></g>
+<circle cx="279.1749553558527" cy="188.904337878795" r="9" stroke="#9a6a28" stroke-opacity="0.8" stroke-width="1.6" fill="none"/>
+<path d="M279.1749553558527,188.904337878795 l0,-6 M279.1749553558527,188.904337878795 l5,2" stroke="#9a6a28" stroke-opacity="0.8" stroke-width="1.6" fill="none"/>
+<g filter="url(#lift)"><circle cx="316.3906623166315" cy="156.02946214881356" r="19" fill="url(#panel)" stroke="#9a6a28" stroke-opacity="0.45" stroke-width="1.3"/></g>
+<path d="M313.3906623166315,148.02946214881356 l-2,16 M320.3906623166315,148.02946214881356 l-2,16 M307.3906623166315,153.02946214881356 l16,0 M308.3906623166315,159.02946214881356 l16,0" stroke="#9a6a28" stroke-opacity="0.8" stroke-width="1.6" fill="none"/>
+<circle cx="474" cy="342" r="44" fill="none" stroke="#9a6a28" stroke-opacity="0.4" stroke-width="1.6"/>
+<circle cx="474" cy="342" r="30" fill="none" stroke="#9a6a28" stroke-opacity="0.6" stroke-width="1.6"/>
+<circle cx="474" cy="342" r="17" fill="none" stroke="#9a6a28" stroke-opacity="0.85" stroke-width="1.6"/>
+<line x1="518" y1="342" x2="526" y2="342" stroke="#9a6a28" stroke-opacity="0.45" stroke-width="1.4"/>
+<line x1="512" y1="364" x2="519" y2="368" stroke="#9a6a28" stroke-opacity="0.45" stroke-width="1.4"/>
+<line x1="496" y1="380" x2="500" y2="387" stroke="#9a6a28" stroke-opacity="0.45" stroke-width="1.4"/>
+<line x1="474" y1="386" x2="474" y2="394" stroke="#9a6a28" stroke-opacity="0.45" stroke-width="1.4"/>
+<line x1="452" y1="380" x2="448" y2="387" stroke="#9a6a28" stroke-opacity="0.45" stroke-width="1.4"/>
+<line x1="436" y1="364" x2="429" y2="368" stroke="#9a6a28" stroke-opacity="0.45" stroke-width="1.4"/>
+<line x1="430" y1="342" x2="422" y2="342" stroke="#9a6a28" stroke-opacity="0.45" stroke-width="1.4"/>
+<line x1="436" y1="320" x2="429" y2="316" stroke="#9a6a28" stroke-opacity="0.45" stroke-width="1.4"/>
+<line x1="452" y1="304" x2="448" y2="297" stroke="#9a6a28" stroke-opacity="0.45" stroke-width="1.4"/>
+<line x1="474" y1="298" x2="474" y2="290" stroke="#9a6a28" stroke-opacity="0.45" stroke-width="1.4"/>
+<line x1="496" y1="304" x2="500" y2="297" stroke="#9a6a28" stroke-opacity="0.45" stroke-width="1.4"/>
+<line x1="512" y1="320" x2="519" y2="316" stroke="#9a6a28" stroke-opacity="0.45" stroke-width="1.4"/>
+<circle cx="474" cy="342" r="13.0" fill="url(#halo)" filter="url(#glow)"/>
+<circle cx="474" cy="342" r="5.0" fill="#d59433" stroke="#8a5a20" stroke-opacity="0.4" stroke-width="0.6"/>
+<circle cx="472.5" cy="340.5" r="2.0" fill="#fff3d6"/>
+<path d="M524,322 L812,296 L812,392 L524,362 z" fill="url(#screen)" opacity="0.14"/>
+<ellipse cx="946" cy="344" rx="200" ry="130" fill="url(#heart)" filter="url(#softbig)"/>
+<g filter="url(#lift)"><rect x="812" y="286" width="268" height="116" rx="13" fill="url(#panel)" stroke="#9a6a28" stroke-opacity="0.6" stroke-width="1.5"/></g>
+<rect x="834" y="308" width="120" height="22" rx="11" fill="url(#screen)"/>
+<circle cx="847" cy="319" r="4" fill="#3a2a16"/>
+<rect x="834" y="344" width="163" height="6" rx="3" fill="#b5822f" opacity="0.60"/>
+<rect x="834" y="362" width="133" height="6" rx="3" fill="#b5822f" opacity="0.50"/>
+<circle cx="1040" cy="344.0" r="22" fill="url(#halo)" filter="url(#glow)"/>
+<circle cx="1040" cy="344.0" r="18" fill="none" stroke="#b07d33" stroke-width="1.8"/>
+<path d="M1036,336.0 l8,8 l-8,8" fill="none" stroke="#b07d33" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"/>
+<g>
+<circle cx="327" cy="314" r="1.0" fill="#d59a44" opacity="0.49"/>
+<circle cx="646" cy="470" r="1.3" fill="#d59a44" opacity="0.26"/>
+<circle cx="155" cy="139" r="1.0" fill="#d59a44" opacity="0.41"/>
+<circle cx="354" cy="394" r="1.8" fill="#d59a44" opacity="0.30"/>
+<circle cx="227" cy="203" r="1.0" fill="#d59a44" opacity="0.39"/>
+<circle cx="241" cy="121" r="1.9" fill="#d59a44" opacity="0.33"/>
+<circle cx="725" cy="462" r="1.7" fill="#d59a44" opacity="0.27"/>
+<circle cx="215" cy="161" r="1.7" fill="#d59a44" opacity="0.35"/>
+<circle cx="311" cy="67" r="1.4" fill="#d59a44" opacity="0.32"/>
+<circle cx="164" cy="162" r="1.3" fill="#d59a44" opacity="0.32"/>
+</g>
+<rect width="1200" height="675" fill="url(#vig)"/>
+<rect width="1200" height="675" filter="url(#grain)" opacity="0.04"/>
+<text x="60" y="622" font-family="Mo" font-size="12" letter-spacing="3" fill="#9a6a2c" fill-opacity="0.8">FIELD NOTES</text>
+<text x="1140" y="622" text-anchor="end" font-family="Mo" font-size="12" letter-spacing="2" fill="#9a6a2c" fill-opacity="0.55">06 / 06</text>
+</svg>

--- a/beta/public/images/blog/cockpit-tag-mit-zehn-agenten.svg
+++ b/beta/public/images/blog/cockpit-tag-mit-zehn-agenten.svg
@@ -1,0 +1,152 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 675" width="1200" height="675" role="img" aria-label="Konzept: ein Cockpit mit zehn Scannern faechert zu allen Quellen aus und buendelt sie zu einer einzigen naechsten Handlung">
+<defs>
+<style>@font-face{font-family:'Mo';src:url(data:font/woff2;base64,d09GMgABAAAAAA7QAA8AAAAAHEwAAA53AAGzMwAAAAAAAAAAAAAAAAAAAAAAAAAAGigbIBwqBmA/U1RBVEgAgX4RCAqsLKJ4ATYCJAOCTguBKgAEIAVmByAb5RWjolZyVsaI/uKAJ0MfBYTACKR2WmgcqlNCrcK+9m3czlmg3OwcHiCxvo6QZPbncdv/GWET8qJtEERBQImSHOxSEy4D5oysF+n7WcHPCHmA7t3721fDDjigCbQtoDzwkMOAozGBw67/AcA5+31rZVXPhOpPB4AUsDtw9+LTsEznE561Gxt1gDZhjaQWB8+J0MAycHtU/O9aafMPyBVQIQrZs301proS/yazu8nm/l7miHgKQG6riFzVTAFIWJa1FfKUqxCyklRf5gzEKs6tRLzvreZMHlPkAjmAW1N4Du46AgGgyKk1jwChGpTK4D5GrWGMkYPXe9kCO5Ug5nNhDHkEAGAdmFjlMxWUeFcn3hdnxmBrLQA3QZrmkxSAd/QqCCC0mIfYkT5xVvASyK94+l74Tq/FLLxheEgIG/nf/d9CMOZjFN8MeDUvC5TJMbV9Hh6AjXdWVXaoD8xUE/+FsQk5KkEN+IxnJye9uSdiRRhSOCO4ilwNdTXBxgh8/TFrlBEoUEZFy8LKLSaJNWvJnc4urh6+fv4NG9fXAZRRqlUPa+5BY3SaU0pzLwCx4viQUqUOeQCcbOwYK62ceZuJByicVqLMx0aiKBElypSrUKmKnEI1FbVadTS0dPQMGhiZEIiIBAAAnsJV3v0gZ0uQ3wOAFQMcgOL1ivAhjlwQn/HSiTz8pMi5AEJMxSRQY3men2qBU0UMz7qKfQw4lnx6r0ogy88vKcwvKqyWFhULrmfPlRZJpaJ8gbR4S74uT5YnLcovqC7aIi6xLltziwTloi0iSRG3qN4qLdosXnps06qLBJtyRV9NgeBbz0JBhbaQL68Qt2MP/nIEuYLLlsmWZ9QE8shKLuO9ttiCZy/Fz1CY+dyIS0z7uftJACYXe9/Y/iedxprdSK/bUKx8ZeOtFAKsebAp5io0RXQV2J5VenvFaaPzm0zOCUOJu7Am0EPN6KkAoQTTowa89RHWJCGIR7rzTQwHZt748VxHozbUqbvVQRbmUjmn67cgK3mmMunc5v4tfnHrUKiD32TpDJ8HdRnpTLGoIACnTiHpiLvY5wJ+9NbB0chacSv6Lxehu16fy2+ZCD92Y3/olTmCVH7KSEFbvUV4F4nJwtURVqcj5xxlmMBMHpVBOoVkGomkpBI6wLdU4HbEmhqarA39ve9+0juOO9mPJooBQM+h9MK7k1g6QtKazfdEvK41/ZOHjJwR6uhi7jdUwZnDq3lnzEa+JmNzztm1jpGleR+Gh19qljughLpWO3nkE0VeMqfscHpK1zDYUssByGubUJhiTdUnn/TL62V+5hePkNMus4fMMLVm+U3ui2IL1MHVOl9JYHiI4soOpnVLBRKxXDU5xywqC+NHmqC8iUmKM9S9pZt1h7qXwgJHdDnswU3Q8hAimT+AvjmKagdZvZWidvQCZyj5LGQpqe+LtAT/QOWDnTsvwf9zuHzm9f0eCX+WgTHlWgXswYnnFhreUDOYetavvyVd/ndO0Vd48OiEWcj+Sm+hmP25PRp90SADQaHPzzdHf2gVGBiyqjHSVzBJR+l1pQDVWFPU1obCB4Yzj0mdeYh1nqQSrTbJ+jRnXkKFOHZTqrVZWgRcb72sciG+biu29/Ieg3tdfM0ISQqtJf7f/v6w/d+W/YwjGvOf9GEt/aNJ6jeHMuZv3t7uePVMwz2yjiOuI14iqaSDUAotbndJ0pqixMHF/R8xEP2BzpG4cuUNzcW42HRfEiZz7dXwIiKf4I/8dfsQd45FzvZpTG3B6UMxMHH5PH7iL7Qasj3U2swLBlkvLmTsQ9zzrIkqdlFxXDnPY2iaGNRSJoRMhzFK5U/enLOSo5Mf3nvmyeFun1c10qd2JcTwxwNs9snZuX62VuUPVetznGmVJtTA7RmcPCZxXCRoM1pCTeg4PIe8lkaj14LmoE6SnM3YL5+atl8+yybbDixtGm0RSsPxiNkS9lTv5Vqq94Q9FmcyKcasQDZz6CCw2au4tTi6YGoKnb/WzDUnIgNTh48cmVobiACbvQmzn0Xj0S+6MPRk74ofs7CNjtN6UElCM3HvZUvTzstn2YS7x+LtE3syQqk7mmgyRTzKvVyLak/UYzEEG1RtO6+J/91P86+cf7k+Fq4Fe5bJ3HzczRkmy7TK/q1A45tLbsZ3Lb4BkEnIfpt1jECJXF6SSiCEcPJN5s251SNw5KMZw/jQV49nmWzDH/33yy+HnixzwbXHYxDGDsnz5pjs/mMDSnzg/iwzl3dIDmR2qWDt4+OYresnx4NagmeS9svnFghZY5y0MHePRMIUdlXvaW2t3ht2m3zpRh/IPTk3YLNvolGDrcPnI5TPhPZvHFjAMZ/LHfPiBVie20czy+Fd3sf3WlS/qoObB8k5I38xE/smuvV14YA6biP5pE3oLX6GkT5UtubRnFYytR9FPA5nxI32g1ESmnb4R4SBjLBHQyG5Xu/dWlZZ8SGuiW+mNrJ6ZbDRbmYH9RTVb7X35royQlbuccvrPRGnofxpqswjY7b02WqbbWYHM6oFYuotnIffmgK1ZGLP8UvPM8+noy2hEKm0K5cyPeDX0ePc/cdvfSTnuMFI5HHWfWpBxMuBLADJhiX7Ke1W7An6R3se7Og5ZadapuvBzke7e84oWwZ4FW9d2nVxyLPrjUsrQM8cu2MJv31+B6dh+KxQH6usc6l9NGKkN1f67G6L6cX70zliNMGxHYNTve/K/pNWIPqkoorPJnKknWSsRE4ZA1WVnlrNxaWZs8rlSggX1vh3bHz0ecF8OIsVB9d+8JfWkL1e43IyaZB/kijmDQ+2cOEBt86vqUo57VVpnxYshWjUa1vB2LY86kO2lhpb8zUp4W2k2UDFBzguPkAZkO3elPAaB9OqhYJCjv/wpNpX+sPaQQXOhgXzz99a5d9RFav3aavSdmdVyq/RucMDXEt4EHSFoRGvdQVj6/KQj/IPumzLmW37BZhO+hs89U9kcjaSM+z3PoUwHAnYHFEErzYEgih0DbqmNKe84aMn0CMIlBdbWuQO//Up4W1PO4Jhi5VRJXQN3gG3dToUtkz1uT3mtGEHpr93mtL9GiTyNbdBc05V1FejIcNt8Xi0DXqyWHXyuX/4t6ssUb2StSWxI2KkzK5wBNmBRq9dufYrKn3yTnQnhtHT0VXVnfXfrG1CLhkVCNPAZvFLxM6JFz98u77v+j/6R48B6a7tZYayVbSPQojaqNyFPkSglEV4sycfY/VptHqv0F1wvDNQ77Kk+jowDrxZtulvVV0cY98z5XsbcPcHHz7rgjC1S+WgG1WsOYkdyBK2q9wVCo/OAepCauTZsCRyiMLTlpPYttIyGKPoAY4joibPArHTr4oS87c7uCZHrCeiXaUoQLhXTEXuIPbdn3f6W/5of2srjJZf41FXpdzuypRXDbmn47z79xHkDlUTNyfXVHc7MR/96jltL1TigUwa+m8FsOjWIy+s3YpezD1+Ntfn9VhGwyPV0XtqS+ZfRNBY6O/WmmldSjhBmppsrvKqLa23nR0WMUqHWlMXyKjcnrTGEF5NCVsKglXW1YodF57yR3NRRmmr1Ro9bZVA/+5t7OxocHeN9sZ9SYYUwC2sTp8wth0YXnDRrhh2uGqGwiXW2lit09/UqL3HaQ8E3b/DUiQUQP/if+WyyhPQa0+g1xHkFMZah9qS2BkxBi3OAB2wYxl9ICtxZUj443sxd/69t+QwB1YH/Brf3ZHx+INvC66/eMgfWZ4FjI9I7iK6jnniyBM9d/If0l2nvCbeF46cjhw7L+oq3/VYLnfR3Wfczb2Ov76zEeI4Nk2iS5aeaQTzvVv+i/HNst2TkYmM7fKp6RYTbCQ6zrKZngK38UwkoSf9ir2pjEDI1esCfkImhfD/BnaK70Edis9iSjJrxB9i0Ic0C3Ojg6b8e2+ukv/+gzbERAoCGWFh/5HlaarfYOQcxsoo9lKKnxh/rWv7MRjkkunlMUEqLRS6sMmlDm39sl57XnCnxozN8tdcSpPf7PH6GscywvzYfFe/v1djTNo8cZoWy5j83v6oz90+rYOD53DR5Hvcmwxmzsl8J+gAlcTfp7NnUEa4HLU7/HEc0lcGPQptTVgp5DQnLGF1qXD9f9Onpb4+p3k0EHCMjTigTkJPBK3H96Z3nu2aGfLEmlIqY+ilTO7dF9tsCY/mENGz4dIRuspA9tssI1TUOTFmDyTIZDqG6KS3PqRQB3Q6RShQAw+N2d+efC7K7scfRj2hjtMdZ+26hAW1hJzUulv9kZaeUPGGh1DYYzalOvRNTZ16Y8rsocIvbggXsz0Rv7t1QksmyIzL64whOkYjpzfj8nMWn9li8NhsVq/NAHmgek3fFR/Xtxo3W23YUzdm3E6umqIpmnnO75dWluCHixsvNi4tTNiuheHRDXyOpmeF+X9iAzHY8G+0PgrdoxEfPqHsJIoSKH2yByITJ5afEAxij8QJKAC/zGOLnj8n4kRE4vqt4aqernQXQ2mwPuXvP4AYkwtxdVuUXJp8C5SwnNCPJK3ESYldMTVR7dHapDjEmKL+0pQgRmUQ+9l7wS+nwbWPcO3dC1sBYDsAz8lfBsX6jzy9ADvs9Dau/8pT8J4gGoBXL6aPrQ/xXcqahxLJQiLxZ8n3AMSu/gX4RY869bLErYaidWdtu8T+Wx6f/yUBwGfpa1Jws1+l//9l/H+Od4KgAsK891bWuzHDS1cT/rtPkBynmgTxKz1mwvYrsKCIZaknDXagSYmhB/RElm+voAK5XW1dAVRyBT0pgYwALJH51IQDKoiexo4RWwZKwGQFokUSix1pYgE2ghEaKJ5HdhbWm7upfAD4nn6c8CuM0ILI0EUwWjHg6gQQAHDypxqDihBOmp/OEzCiAXk+8IgBXowAKCIGeex2rXiLes+4Xv1mjeg0JWVXg9ZrwAzKjE4jonW3uHGjEB57Tzp5fY1OBoQT) format('woff2');}</style>
+<radialGradient id="ground" cx="40%" cy="50%" r="80%">
+  <stop offset="0%" stop-color="#1c1610"/><stop offset="55%" stop-color="#120e0a"/>
+  <stop offset="100%" stop-color="#090705"/>
+</radialGradient>
+<radialGradient id="coreglow" cx="50%" cy="50%" r="50%">
+  <stop offset="0%" stop-color="#f5bd62" stop-opacity="0.52"/>
+  <stop offset="45%" stop-color="#c8863c" stop-opacity="0.20"/>
+  <stop offset="100%" stop-color="#c8863c" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="heart" cx="50%" cy="50%" r="50%">
+  <stop offset="0%" stop-color="#ffdf99" stop-opacity="0.55"/>
+  <stop offset="60%" stop-color="#f0ab4c" stop-opacity="0.12"/>
+  <stop offset="100%" stop-color="#f0ab4c" stop-opacity="0"/>
+</radialGradient>
+<linearGradient id="cell" x1="0" y1="0" x2="0" y2="1">
+  <stop offset="0%" stop-color="#eab866"/><stop offset="52%" stop-color="#b07e40"/>
+  <stop offset="100%" stop-color="#5f4223"/>
+</linearGradient>
+<radialGradient id="hot" cx="50%" cy="42%" r="60%">
+  <stop offset="0%" stop-color="#ffe0a0"/><stop offset="55%" stop-color="#e2a24a"/>
+  <stop offset="100%" stop-color="#7a5327"/>
+</radialGradient>
+<radialGradient id="screen" cx="50%" cy="38%" r="75%">
+  <stop offset="0%" stop-color="#ffdf9c"/><stop offset="60%" stop-color="#e0a24c"/>
+  <stop offset="100%" stop-color="#9c6e34"/>
+</radialGradient>
+<linearGradient id="panel" x1="0" y1="0" x2="0" y2="1">
+  <stop offset="0%" stop-color="#2a2015" stop-opacity="0.92"/>
+  <stop offset="100%" stop-color="#140f0a" stop-opacity="0.92"/>
+</linearGradient>
+<radialGradient id="vig" cx="50%" cy="48%" r="62%">
+  <stop offset="60%" stop-color="#000" stop-opacity="0"/>
+  <stop offset="100%" stop-color="#050403" stop-opacity="0.74"/>
+</radialGradient>
+<filter id="glow" x="-120%" y="-120%" width="340%" height="340%"><feGaussianBlur stdDeviation="7"/></filter>
+<filter id="glowbig" x="-150%" y="-150%" width="400%" height="400%"><feGaussianBlur stdDeviation="13"/></filter>
+<filter id="softbig" x="-60%" y="-60%" width="220%" height="220%"><feGaussianBlur stdDeviation="26"/></filter>
+<filter id="grain"><feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="2" stitchTiles="stitch"/>
+  <feColorMatrix type="matrix" values="0 0 0 0 0.9  0 0 0 0 0.7  0 0 0 0 0.4  0 0 0 0.5 0"/></filter>
+</defs>
+<rect width="1200" height="675" fill="url(#ground)"/>
+<ellipse cx="474" cy="342" rx="300" ry="260" fill="url(#coreglow)" filter="url(#softbig)"/>
+<line x1="316" y1="528" x2="474" y2="342" stroke="#d89b4d" stroke-width="1.4" stroke-opacity="0.32"/>
+<circle cx="405" cy="423" r="6.8" fill="#ffcf7a" opacity="0.5" filter="url(#glow)"/>
+<circle cx="405" cy="423" r="2.0" fill="#fff3d6"/>
+<line x1="279" y1="495" x2="474" y2="342" stroke="#d89b4d" stroke-width="1.4" stroke-opacity="0.32"/>
+<circle cx="377" cy="418" r="6.8" fill="#ffcf7a" opacity="0.5" filter="url(#glow)"/>
+<circle cx="377" cy="418" r="2.0" fill="#fff3d6"/>
+<line x1="250" y1="456" x2="474" y2="342" stroke="#d89b4d" stroke-width="1.4" stroke-opacity="0.32"/>
+<circle cx="402" cy="379" r="6.8" fill="#ffcf7a" opacity="0.5" filter="url(#glow)"/>
+<circle cx="402" cy="379" r="2.0" fill="#fff3d6"/>
+<line x1="230" y1="412" x2="474" y2="342" stroke="#d89b4d" stroke-width="1.4" stroke-opacity="0.32"/>
+<circle cx="346" cy="379" r="6.8" fill="#ffcf7a" opacity="0.5" filter="url(#glow)"/>
+<circle cx="346" cy="379" r="2.0" fill="#fff3d6"/>
+<line x1="219" y1="366" x2="474" y2="342" stroke="#d89b4d" stroke-width="1.4" stroke-opacity="0.32"/>
+<circle cx="382" cy="351" r="6.8" fill="#ffcf7a" opacity="0.5" filter="url(#glow)"/>
+<circle cx="382" cy="351" r="2.0" fill="#fff3d6"/>
+<line x1="219" y1="318" x2="474" y2="342" stroke="#d89b4d" stroke-width="1.4" stroke-opacity="0.32"/>
+<circle cx="367" cy="332" r="6.8" fill="#ffcf7a" opacity="0.5" filter="url(#glow)"/>
+<circle cx="367" cy="332" r="2.0" fill="#fff3d6"/>
+<line x1="230" y1="272" x2="474" y2="342" stroke="#d89b4d" stroke-width="1.4" stroke-opacity="0.32"/>
+<circle cx="345" cy="305" r="6.8" fill="#ffcf7a" opacity="0.5" filter="url(#glow)"/>
+<circle cx="345" cy="305" r="2.0" fill="#fff3d6"/>
+<line x1="250" y1="228" x2="474" y2="342" stroke="#d89b4d" stroke-width="1.4" stroke-opacity="0.32"/>
+<circle cx="391" cy="300" r="6.8" fill="#ffcf7a" opacity="0.5" filter="url(#glow)"/>
+<circle cx="391" cy="300" r="2.0" fill="#fff3d6"/>
+<line x1="279" y1="189" x2="474" y2="342" stroke="#d89b4d" stroke-width="1.4" stroke-opacity="0.32"/>
+<circle cx="369" cy="260" r="6.8" fill="#ffcf7a" opacity="0.5" filter="url(#glow)"/>
+<circle cx="369" cy="260" r="2.0" fill="#fff3d6"/>
+<line x1="316" y1="156" x2="474" y2="342" stroke="#d89b4d" stroke-width="1.4" stroke-opacity="0.32"/>
+<circle cx="411" cy="268" r="6.8" fill="#ffcf7a" opacity="0.5" filter="url(#glow)"/>
+<circle cx="411" cy="268" r="2.0" fill="#fff3d6"/>
+<circle cx="316.3906623166315" cy="527.9705378511865" r="19" fill="url(#panel)" stroke="#ffdca0" stroke-opacity="0.4" stroke-width="1.3"/>
+<rect x="307.3906623166315" y="521.9705378511865" width="18" height="13" rx="2" stroke="#ffdca0" stroke-opacity="0.8" stroke-width="1.6" fill="none"/>
+<path d="M308.3906623166315,523.9705378511865 L316.3906623166315,529.9705378511865 L324.3906623166315,523.9705378511865" stroke="#ffdca0" stroke-opacity="0.8" stroke-width="1.6" fill="none"/>
+<circle cx="279.1749553558527" cy="495.09566212120495" r="19" fill="url(#panel)" stroke="#ffdca0" stroke-opacity="0.4" stroke-width="1.3"/>
+<rect x="270.1749553558527" y="487.09566212120495" width="18" height="13" rx="4" stroke="#ffdca0" stroke-opacity="0.8" stroke-width="1.6" fill="none"/>
+<path d="M275.1749553558527,500.09566212120495 l0,4 l5,-4 z" fill="#ffdca0" opacity="0.7" stroke="none"/>
+<circle cx="249.85709278666477" cy="456.0145734340067" r="19" fill="url(#panel)" stroke="#ffdca0" stroke-opacity="0.4" stroke-width="1.3"/>
+<rect x="240.85709278666477" y="449.0145734340067" width="18" height="15" rx="2" stroke="#ffdca0" stroke-opacity="0.8" stroke-width="1.6" fill="none"/>
+<line x1="240.85709278666477" y1="454.0145734340067" x2="258.8570927866648" y2="454.0145734340067" stroke="#ffdca0" stroke-opacity="0.8" stroke-width="1.6" fill="none"/>
+<circle cx="244.85709278666477" cy="460.0145734340067" r="1.4" fill="#ffdca0" opacity="0.7"/>
+<circle cx="249.85709278666477" cy="460.0145734340067" r="1.4" fill="#ffdca0" opacity="0.7"/>
+<circle cx="254.85709278666477" cy="460.0145734340067" r="1.4" fill="#ffdca0" opacity="0.7"/>
+<circle cx="229.62556614458063" cy="412.3115463250818" r="19" fill="url(#panel)" stroke="#ffdca0" stroke-opacity="0.4" stroke-width="1.3"/>
+<path d="M223.62556614458063,404.3115463250818 L238.62556614458063,412.3115463250818 L223.62556614458063,420.3115463250818 z" stroke="#ffdca0" stroke-opacity="0.8" stroke-width="1.6" fill="none"/>
+<circle cx="219.30052383257055" cy="365.75822010383314" r="19" fill="url(#panel)" stroke="#ffdca0" stroke-opacity="0.4" stroke-width="1.3"/>
+<path d="M210.30052383257055,359.75822010383314 l6,0 l2,3 l10,0 l0,9 l-18,0 z" stroke="#ffdca0" stroke-opacity="0.8" stroke-width="1.6" fill="none"/>
+<circle cx="219.30052383257055" cy="318.2417798961669" r="19" fill="url(#panel)" stroke="#ffdca0" stroke-opacity="0.4" stroke-width="1.3"/>
+<path d="M212.30052383257055,322.2417798961669 q0,-14 7,-14 q7,0 7,14 z" stroke="#ffdca0" stroke-opacity="0.8" stroke-width="1.6" fill="none"/>
+<circle cx="219.30052383257055" cy="325.2417798961669" r="2" fill="#ffdca0" opacity="0.7"/>
+<circle cx="229.62556614458057" cy="271.6884536749184" r="19" fill="url(#panel)" stroke="#ffdca0" stroke-opacity="0.4" stroke-width="1.3"/>
+<path d="M222.62556614458057,262.6884536749184 l10,0 l5,5 l0,13 l-15,0 z" stroke="#ffdca0" stroke-opacity="0.8" stroke-width="1.6" fill="none"/>
+<line x1="225.62556614458057" y1="271.6884536749184" x2="234.62556614458057" y2="271.6884536749184" stroke="#ffdca0" stroke-opacity="0.8" stroke-width="1.6" fill="none"/>
+<line x1="225.62556614458057" y1="275.6884536749184" x2="234.62556614458057" y2="275.6884536749184" stroke="#ffdca0" stroke-opacity="0.8" stroke-width="1.6" fill="none"/>
+<circle cx="249.85709278666474" cy="227.98542656599335" r="19" fill="url(#panel)" stroke="#ffdca0" stroke-opacity="0.4" stroke-width="1.3"/>
+<path d="M240.85709278666474,225.98542656599335 l7,-7 l10,0 l0,10 l-7,7 z" stroke="#ffdca0" stroke-opacity="0.8" stroke-width="1.6" fill="none"/>
+<circle cx="251.85709278666474" cy="225.98542656599335" r="2" fill="#ffdca0" opacity="0.7"/>
+<circle cx="279.1749553558527" cy="188.904337878795" r="19" fill="url(#panel)" stroke="#ffdca0" stroke-opacity="0.4" stroke-width="1.3"/>
+<circle cx="279.1749553558527" cy="188.904337878795" r="9" stroke="#ffdca0" stroke-opacity="0.8" stroke-width="1.6" fill="none"/>
+<path d="M279.1749553558527,188.904337878795 l0,-6 M279.1749553558527,188.904337878795 l5,2" stroke="#ffdca0" stroke-opacity="0.8" stroke-width="1.6" fill="none"/>
+<circle cx="316.3906623166315" cy="156.02946214881356" r="19" fill="url(#panel)" stroke="#ffdca0" stroke-opacity="0.4" stroke-width="1.3"/>
+<path d="M313.3906623166315,148.02946214881356 l-2,16 M320.3906623166315,148.02946214881356 l-2,16 M307.3906623166315,153.02946214881356 l16,0 M308.3906623166315,159.02946214881356 l16,0" stroke="#ffdca0" stroke-opacity="0.8" stroke-width="1.6" fill="none"/>
+<circle cx="474" cy="342" r="44" fill="none" stroke="#f0c479" stroke-opacity="0.3" stroke-width="1.6"/>
+<circle cx="474" cy="342" r="30" fill="none" stroke="#f0c479" stroke-opacity="0.5" stroke-width="1.6"/>
+<circle cx="474" cy="342" r="17" fill="none" stroke="#f0c479" stroke-opacity="0.75" stroke-width="1.6"/>
+<line x1="518" y1="342" x2="526" y2="342" stroke="#f0c479" stroke-opacity="0.4" stroke-width="1.4"/>
+<line x1="512" y1="364" x2="519" y2="368" stroke="#f0c479" stroke-opacity="0.4" stroke-width="1.4"/>
+<line x1="496" y1="380" x2="500" y2="387" stroke="#f0c479" stroke-opacity="0.4" stroke-width="1.4"/>
+<line x1="474" y1="386" x2="474" y2="394" stroke="#f0c479" stroke-opacity="0.4" stroke-width="1.4"/>
+<line x1="452" y1="380" x2="448" y2="387" stroke="#f0c479" stroke-opacity="0.4" stroke-width="1.4"/>
+<line x1="436" y1="364" x2="429" y2="368" stroke="#f0c479" stroke-opacity="0.4" stroke-width="1.4"/>
+<line x1="430" y1="342" x2="422" y2="342" stroke="#f0c479" stroke-opacity="0.4" stroke-width="1.4"/>
+<line x1="436" y1="320" x2="429" y2="316" stroke="#f0c479" stroke-opacity="0.4" stroke-width="1.4"/>
+<line x1="452" y1="304" x2="448" y2="297" stroke="#f0c479" stroke-opacity="0.4" stroke-width="1.4"/>
+<line x1="474" y1="298" x2="474" y2="290" stroke="#f0c479" stroke-opacity="0.4" stroke-width="1.4"/>
+<line x1="496" y1="304" x2="500" y2="297" stroke="#f0c479" stroke-opacity="0.4" stroke-width="1.4"/>
+<line x1="512" y1="320" x2="519" y2="316" stroke="#f0c479" stroke-opacity="0.4" stroke-width="1.4"/>
+<circle cx="474" cy="342" r="17.0" fill="#ffcf7a" opacity="0.5" filter="url(#glow)"/>
+<circle cx="474" cy="342" r="5.0" fill="#fff3d6"/>
+<path d="M524,322 L812,296 L812,392 L524,362 z" fill="url(#screen)" opacity="0.10"/>
+<ellipse cx="946" cy="344" rx="200" ry="130" fill="url(#heart)" filter="url(#softbig)"/>
+<rect x="812" y="286" width="268" height="116" rx="13" fill="url(#panel)" stroke="#ffdca0" stroke-opacity="0.6" stroke-width="1.6"/>
+<rect x="834" y="308" width="120" height="22" rx="11" fill="url(#screen)" opacity="0.95"/>
+<circle cx="847" cy="319" r="4" fill="#3a2a16"/>
+<rect x="834" y="344" width="163" height="6" rx="3" fill="#e0a24c" opacity="0.50"/>
+<rect x="834" y="362" width="133" height="6" rx="3" fill="#e0a24c" opacity="0.40"/>
+<circle cx="1040" cy="344.0" r="22" fill="#ffcf7a" opacity="0.4" filter="url(#glow)"/>
+<circle cx="1040" cy="344.0" r="18" fill="none" stroke="#ffe7b0" stroke-width="1.8"/>
+<path d="M1036,336.0 l8,8 l-8,8" fill="none" stroke="#ffe7b0" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/>
+<g>
+<circle cx="327" cy="314" r="0.8" fill="#f4c983" opacity="0.49" filter="url(#glow)"/>
+<circle cx="646" cy="470" r="1.1" fill="#f4c983" opacity="0.22" filter="url(#glow)"/>
+<circle cx="155" cy="139" r="0.8" fill="#f4c983" opacity="0.39" filter="url(#glow)"/>
+<circle cx="354" cy="394" r="1.8" fill="#f4c983" opacity="0.27" filter="url(#glow)"/>
+<circle cx="227" cy="203" r="0.8" fill="#f4c983" opacity="0.38" filter="url(#glow)"/>
+<circle cx="241" cy="121" r="2.0" fill="#f4c983" opacity="0.30" filter="url(#glow)"/>
+<circle cx="725" cy="462" r="1.7" fill="#f4c983" opacity="0.24" filter="url(#glow)"/>
+<circle cx="215" cy="161" r="1.8" fill="#f4c983" opacity="0.33" filter="url(#glow)"/>
+<circle cx="311" cy="67" r="1.3" fill="#f4c983" opacity="0.29" filter="url(#glow)"/>
+<circle cx="164" cy="162" r="1.2" fill="#f4c983" opacity="0.30" filter="url(#glow)"/>
+<circle cx="436" cy="292" r="1.9" fill="#f4c983" opacity="0.25" filter="url(#glow)"/>
+<circle cx="181" cy="184" r="1.1" fill="#f4c983" opacity="0.35" filter="url(#glow)"/>
+</g>
+<rect width="1200" height="675" fill="url(#vig)"/>
+<rect width="1200" height="675" filter="url(#grain)" opacity="0.05"/>
+<text x="60" y="622" font-family="Mo" font-size="12" letter-spacing="3" fill="#e8b968" fill-opacity="0.55">FIELD NOTES</text>
+<text x="1140" y="622" text-anchor="end" font-family="Mo" font-size="12" letter-spacing="2" fill="#e8b968" fill-opacity="0.38">06 / 06</text>
+</svg>

--- a/beta/public/images/blog/ki-agenten-betriebssystem-light.svg
+++ b/beta/public/images/blog/ki-agenten-betriebssystem-light.svg
@@ -1,0 +1,224 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 675" width="1200" height="675" role="img" aria-label="Konzept (hell): Feature-Requests fliessen aus einem Terminal, Agenten bauen daraus das System">
+<defs>
+<style>@font-face{font-family:'Mo';src:url(data:font/woff2;base64,d09GMgABAAAAAA7QAA8AAAAAHEwAAA53AAGzMwAAAAAAAAAAAAAAAAAAAAAAAAAAGigbIBwqBmA/U1RBVEgAgX4RCAqsLKJ4ATYCJAOCTguBKgAEIAVmByAb5RWjolZyVsaI/uKAJ0MfBYTACKR2WmgcqlNCrcK+9m3czlmg3OwcHiCxvo6QZPbncdv/GWET8qJtEERBQImSHOxSEy4D5oysF+n7WcHPCHmA7t3721fDDjigCbQtoDzwkMOAozGBw67/AcA5+31rZVXPhOpPB4AUsDtw9+LTsEznE561Gxt1gDZhjaQWB8+J0MAycHtU/O9aafMPyBVQIQrZs301proS/yazu8nm/l7miHgKQG6riFzVTAFIWJa1FfKUqxCyklRf5gzEKs6tRLzvreZMHlPkAjmAW1N4Du46AgGgyKk1jwChGpTK4D5GrWGMkYPXe9kCO5Ug5nNhDHkEAGAdmFjlMxWUeFcn3hdnxmBrLQA3QZrmkxSAd/QqCCC0mIfYkT5xVvASyK94+l74Tq/FLLxheEgIG/nf/d9CMOZjFN8MeDUvC5TJMbV9Hh6AjXdWVXaoD8xUE/+FsQk5KkEN+IxnJye9uSdiRRhSOCO4ilwNdTXBxgh8/TFrlBEoUEZFy8LKLSaJNWvJnc4urh6+fv4NG9fXAZRRqlUPa+5BY3SaU0pzLwCx4viQUqUOeQCcbOwYK62ceZuJByicVqLMx0aiKBElypSrUKmKnEI1FbVadTS0dPQMGhiZEIiIBAAAnsJV3v0gZ0uQ3wOAFQMcgOL1ivAhjlwQn/HSiTz8pMi5AEJMxSRQY3men2qBU0UMz7qKfQw4lnx6r0ogy88vKcwvKqyWFhULrmfPlRZJpaJ8gbR4S74uT5YnLcovqC7aIi6xLltziwTloi0iSRG3qN4qLdosXnps06qLBJtyRV9NgeBbz0JBhbaQL68Qt2MP/nIEuYLLlsmWZ9QE8shKLuO9ttiCZy/Fz1CY+dyIS0z7uftJACYXe9/Y/iedxprdSK/bUKx8ZeOtFAKsebAp5io0RXQV2J5VenvFaaPzm0zOCUOJu7Am0EPN6KkAoQTTowa89RHWJCGIR7rzTQwHZt748VxHozbUqbvVQRbmUjmn67cgK3mmMunc5v4tfnHrUKiD32TpDJ8HdRnpTLGoIACnTiHpiLvY5wJ+9NbB0chacSv6Lxehu16fy2+ZCD92Y3/olTmCVH7KSEFbvUV4F4nJwtURVqcj5xxlmMBMHpVBOoVkGomkpBI6wLdU4HbEmhqarA39ve9+0juOO9mPJooBQM+h9MK7k1g6QtKazfdEvK41/ZOHjJwR6uhi7jdUwZnDq3lnzEa+JmNzztm1jpGleR+Gh19qljughLpWO3nkE0VeMqfscHpK1zDYUssByGubUJhiTdUnn/TL62V+5hePkNMus4fMMLVm+U3ui2IL1MHVOl9JYHiI4soOpnVLBRKxXDU5xywqC+NHmqC8iUmKM9S9pZt1h7qXwgJHdDnswU3Q8hAimT+AvjmKagdZvZWidvQCZyj5LGQpqe+LtAT/QOWDnTsvwf9zuHzm9f0eCX+WgTHlWgXswYnnFhreUDOYetavvyVd/ndO0Vd48OiEWcj+Sm+hmP25PRp90SADQaHPzzdHf2gVGBiyqjHSVzBJR+l1pQDVWFPU1obCB4Yzj0mdeYh1nqQSrTbJ+jRnXkKFOHZTqrVZWgRcb72sciG+biu29/Ieg3tdfM0ISQqtJf7f/v6w/d+W/YwjGvOf9GEt/aNJ6jeHMuZv3t7uePVMwz2yjiOuI14iqaSDUAotbndJ0pqixMHF/R8xEP2BzpG4cuUNzcW42HRfEiZz7dXwIiKf4I/8dfsQd45FzvZpTG3B6UMxMHH5PH7iL7Qasj3U2swLBlkvLmTsQ9zzrIkqdlFxXDnPY2iaGNRSJoRMhzFK5U/enLOSo5Mf3nvmyeFun1c10qd2JcTwxwNs9snZuX62VuUPVetznGmVJtTA7RmcPCZxXCRoM1pCTeg4PIe8lkaj14LmoE6SnM3YL5+atl8+yybbDixtGm0RSsPxiNkS9lTv5Vqq94Q9FmcyKcasQDZz6CCw2au4tTi6YGoKnb/WzDUnIgNTh48cmVobiACbvQmzn0Xj0S+6MPRk74ofs7CNjtN6UElCM3HvZUvTzstn2YS7x+LtE3syQqk7mmgyRTzKvVyLak/UYzEEG1RtO6+J/91P86+cf7k+Fq4Fe5bJ3HzczRkmy7TK/q1A45tLbsZ3Lb4BkEnIfpt1jECJXF6SSiCEcPJN5s251SNw5KMZw/jQV49nmWzDH/33yy+HnixzwbXHYxDGDsnz5pjs/mMDSnzg/iwzl3dIDmR2qWDt4+OYresnx4NagmeS9svnFghZY5y0MHePRMIUdlXvaW2t3ht2m3zpRh/IPTk3YLNvolGDrcPnI5TPhPZvHFjAMZ/LHfPiBVie20czy+Fd3sf3WlS/qoObB8k5I38xE/smuvV14YA6biP5pE3oLX6GkT5UtubRnFYytR9FPA5nxI32g1ESmnb4R4SBjLBHQyG5Xu/dWlZZ8SGuiW+mNrJ6ZbDRbmYH9RTVb7X35royQlbuccvrPRGnofxpqswjY7b02WqbbWYHM6oFYuotnIffmgK1ZGLP8UvPM8+noy2hEKm0K5cyPeDX0ePc/cdvfSTnuMFI5HHWfWpBxMuBLADJhiX7Ke1W7An6R3se7Og5ZadapuvBzke7e84oWwZ4FW9d2nVxyLPrjUsrQM8cu2MJv31+B6dh+KxQH6usc6l9NGKkN1f67G6L6cX70zliNMGxHYNTve/K/pNWIPqkoorPJnKknWSsRE4ZA1WVnlrNxaWZs8rlSggX1vh3bHz0ecF8OIsVB9d+8JfWkL1e43IyaZB/kijmDQ+2cOEBt86vqUo57VVpnxYshWjUa1vB2LY86kO2lhpb8zUp4W2k2UDFBzguPkAZkO3elPAaB9OqhYJCjv/wpNpX+sPaQQXOhgXzz99a5d9RFav3aavSdmdVyq/RucMDXEt4EHSFoRGvdQVj6/KQj/IPumzLmW37BZhO+hs89U9kcjaSM+z3PoUwHAnYHFEErzYEgih0DbqmNKe84aMn0CMIlBdbWuQO//Up4W1PO4Jhi5VRJXQN3gG3dToUtkz1uT3mtGEHpr93mtL9GiTyNbdBc05V1FejIcNt8Xi0DXqyWHXyuX/4t6ssUb2StSWxI2KkzK5wBNmBRq9dufYrKn3yTnQnhtHT0VXVnfXfrG1CLhkVCNPAZvFLxM6JFz98u77v+j/6R48B6a7tZYayVbSPQojaqNyFPkSglEV4sycfY/VptHqv0F1wvDNQ77Kk+jowDrxZtulvVV0cY98z5XsbcPcHHz7rgjC1S+WgG1WsOYkdyBK2q9wVCo/OAepCauTZsCRyiMLTlpPYttIyGKPoAY4joibPArHTr4oS87c7uCZHrCeiXaUoQLhXTEXuIPbdn3f6W/5of2srjJZf41FXpdzuypRXDbmn47z79xHkDlUTNyfXVHc7MR/96jltL1TigUwa+m8FsOjWIy+s3YpezD1+Ntfn9VhGwyPV0XtqS+ZfRNBY6O/WmmldSjhBmppsrvKqLa23nR0WMUqHWlMXyKjcnrTGEF5NCVsKglXW1YodF57yR3NRRmmr1Ro9bZVA/+5t7OxocHeN9sZ9SYYUwC2sTp8wth0YXnDRrhh2uGqGwiXW2lit09/UqL3HaQ8E3b/DUiQUQP/if+WyyhPQa0+g1xHkFMZah9qS2BkxBi3OAB2wYxl9ICtxZUj443sxd/69t+QwB1YH/Brf3ZHx+INvC66/eMgfWZ4FjI9I7iK6jnniyBM9d/If0l2nvCbeF46cjhw7L+oq3/VYLnfR3Wfczb2Ov76zEeI4Nk2iS5aeaQTzvVv+i/HNst2TkYmM7fKp6RYTbCQ6zrKZngK38UwkoSf9ir2pjEDI1esCfkImhfD/BnaK70Edis9iSjJrxB9i0Ic0C3Ojg6b8e2+ukv/+gzbERAoCGWFh/5HlaarfYOQcxsoo9lKKnxh/rWv7MRjkkunlMUEqLRS6sMmlDm39sl57XnCnxozN8tdcSpPf7PH6GscywvzYfFe/v1djTNo8cZoWy5j83v6oz90+rYOD53DR5Hvcmwxmzsl8J+gAlcTfp7NnUEa4HLU7/HEc0lcGPQptTVgp5DQnLGF1qXD9f9Onpb4+p3k0EHCMjTigTkJPBK3H96Z3nu2aGfLEmlIqY+ilTO7dF9tsCY/mENGz4dIRuspA9tssI1TUOTFmDyTIZDqG6KS3PqRQB3Q6RShQAw+N2d+efC7K7scfRj2hjtMdZ+26hAW1hJzUulv9kZaeUPGGh1DYYzalOvRNTZ16Y8rsocIvbggXsz0Rv7t1QksmyIzL64whOkYjpzfj8nMWn9li8NhsVq/NAHmgek3fFR/Xtxo3W23YUzdm3E6umqIpmnnO75dWluCHixsvNi4tTNiuheHRDXyOpmeF+X9iAzHY8G+0PgrdoxEfPqHsJIoSKH2yByITJ5afEAxij8QJKAC/zGOLnj8n4kRE4vqt4aqernQXQ2mwPuXvP4AYkwtxdVuUXJp8C5SwnNCPJK3ESYldMTVR7dHapDjEmKL+0pQgRmUQ+9l7wS+nwbWPcO3dC1sBYDsAz8lfBsX6jzy9ADvs9Dau/8pT8J4gGoBXL6aPrQ/xXcqahxLJQiLxZ8n3AMSu/gX4RY869bLErYaidWdtu8T+Wx6f/yUBwGfpa1Jws1+l//9l/H+Od4KgAsK891bWuzHDS1cT/rtPkBynmgTxKz1mwvYrsKCIZaknDXagSYmhB/RElm+voAK5XW1dAVRyBT0pgYwALJH51IQDKoiexo4RWwZKwGQFokUSix1pYgE2ghEaKJ5HdhbWm7upfAD4nn6c8CuM0ILI0EUwWjHg6gQQAHDypxqDihBOmp/OEzCiAXk+8IgBXowAKCIGeex2rXiLes+4Xv1mjeg0JWVXg9ZrwAzKjE4jonW3uHGjEB57Tzp5fY1OBoQT) format('woff2');}</style>
+<radialGradient id="ground" cx="46%" cy="48%" r="80%">
+  <stop offset="0%" stop-color="#fdfaf3"/><stop offset="58%" stop-color="#f3ecdb"/>
+  <stop offset="100%" stop-color="#e4d9c1"/>
+</radialGradient>
+<radialGradient id="warmth" cx="50%" cy="50%" r="50%">
+  <stop offset="0%" stop-color="#ffdd93" stop-opacity="0.75"/>
+  <stop offset="55%" stop-color="#f2c46a" stop-opacity="0.18"/>
+  <stop offset="100%" stop-color="#f0ab4c" stop-opacity="0"/>
+</radialGradient>
+<linearGradient id="cell" x1="0" y1="0" x2="0" y2="1">
+  <stop offset="0%" stop-color="#f0b957"/><stop offset="55%" stop-color="#d5923c"/>
+  <stop offset="100%" stop-color="#b0742c"/>
+</linearGradient>
+<linearGradient id="hot" x1="0" y1="0" x2="0" y2="1">
+  <stop offset="0%" stop-color="#ffe6a6"/><stop offset="50%" stop-color="#f6c065"/>
+  <stop offset="100%" stop-color="#dc9d3e"/>
+</linearGradient>
+<linearGradient id="screen" x1="0" y1="0" x2="0" y2="1">
+  <stop offset="0%" stop-color="#ffe7ad"/><stop offset="100%" stop-color="#e6ab52"/>
+</linearGradient>
+<radialGradient id="halo" cx="50%" cy="50%" r="50%">
+  <stop offset="0%" stop-color="#f6bf5c" stop-opacity="0.7"/>
+  <stop offset="100%" stop-color="#f6bf5c" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="vig" cx="50%" cy="46%" r="66%">
+  <stop offset="62%" stop-color="#7a5a2e" stop-opacity="0"/>
+  <stop offset="100%" stop-color="#8a6a34" stop-opacity="0.16"/>
+</radialGradient>
+<filter id="soft" x="-120%" y="-120%" width="340%" height="340%"><feGaussianBlur stdDeviation="6"/></filter>
+<filter id="softbig" x="-60%" y="-60%" width="220%" height="220%"><feGaussianBlur stdDeviation="24"/></filter>
+<filter id="lift" x="-40%" y="-40%" width="180%" height="200%">
+  <feDropShadow dx="0" dy="7" stdDeviation="13" flood-color="#6e4e24" flood-opacity="0.28"/>
+</filter>
+<filter id="grain"><feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="2" stitchTiles="stitch"/>
+  <feColorMatrix type="matrix" values="0 0 0 0 0.42  0 0 0 0 0.30  0 0 0 0 0.12  0 0 0 0.5 0"/></filter>
+</defs>
+<rect width="1200" height="675" fill="url(#ground)"/>
+<ellipse cx="300" cy="440" rx="250" ry="190" fill="url(#warmth)" filter="url(#softbig)"/>
+<ellipse cx="905" cy="300" rx="300" ry="250" fill="url(#warmth)" filter="url(#softbig)"/>
+<ellipse cx="905" cy="300" rx="150" ry="130" fill="url(#warmth)" filter="url(#softbig)"/>
+<g fill="none" stroke="#b07a34" stroke-width="1">
+<polygon points="726.0,400.1 709.5,428.7 676.5,428.7 660.0,400.1 676.5,371.5 709.5,371.5" stroke-opacity="0.12"/>
+<polygon points="775.5,142.9 759.0,171.5 726.0,171.5 709.5,142.9 726.0,114.3 759.0,114.3" stroke-opacity="0.15"/>
+<polygon points="775.5,314.4 759.0,342.9 726.0,342.9 709.5,314.4 726.0,285.8 759.0,285.8" stroke-opacity="0.19"/>
+<polygon points="775.5,371.5 759.0,400.1 726.0,400.1 709.5,371.5 726.0,342.9 759.0,342.9" stroke-opacity="0.21"/>
+<polygon points="775.5,428.7 759.0,457.3 726.0,457.3 709.5,428.7 726.0,400.1 759.0,400.1" stroke-opacity="0.23"/>
+<polygon points="825.0,114.3 808.5,142.9 775.5,142.9 759.0,114.3 775.5,85.7 808.5,85.7" stroke-opacity="0.16"/>
+<polygon points="825.0,171.5 808.5,200.1 775.5,200.1 759.0,171.5 775.5,142.9 808.5,142.9" stroke-opacity="0.16"/>
+<polygon points="825.0,457.3 808.5,485.8 775.5,485.8 759.0,457.3 775.5,428.7 808.5,428.7" stroke-opacity="0.16"/>
+<polygon points="874.5,142.9 858.0,171.5 825.0,171.5 808.5,142.9 825.0,114.3 858.0,114.3" stroke-opacity="0.12"/>
+<polygon points="924.0,171.5 907.5,200.1 874.5,200.1 858.0,171.5 874.5,142.9 907.5,142.9" stroke-opacity="0.23"/>
+<polygon points="924.0,457.3 907.5,485.8 874.5,485.8 858.0,457.3 874.5,428.7 907.5,428.7" stroke-opacity="0.19"/>
+<polygon points="973.5,85.7 957.0,114.3 924.0,114.3 907.5,85.7 924.0,57.2 957.0,57.2" stroke-opacity="0.10"/>
+<polygon points="973.5,142.9 957.0,171.5 924.0,171.5 907.5,142.9 924.0,114.3 957.0,114.3" stroke-opacity="0.16"/>
+<polygon points="1023.0,457.3 1006.5,485.8 973.5,485.8 957.0,457.3 973.5,428.7 1006.5,428.7" stroke-opacity="0.10"/>
+<polygon points="1072.5,371.5 1056.0,400.1 1023.0,400.1 1006.5,371.5 1023.0,342.9 1056.0,342.9" stroke-opacity="0.22"/>
+<polygon points="1122.0,285.8 1105.5,314.4 1072.5,314.4 1056.0,285.8 1072.5,257.2 1105.5,257.2" stroke-opacity="0.19"/>
+</g><g fill="none" stroke="#a86f2a" stroke-width="1.1">
+<polygon points="825.0,228.6 808.5,257.2 775.5,257.2 759.0,228.6 775.5,200.1 808.5,200.1" stroke-opacity="0.23"/>
+<polygon points="825.0,285.8 808.5,314.4 775.5,314.4 759.0,285.8 775.5,257.2 808.5,257.2" stroke-opacity="0.44"/>
+<polygon points="825.0,342.9 808.5,371.5 775.5,371.5 759.0,342.9 775.5,314.4 808.5,314.4" stroke-opacity="0.48"/>
+<polygon points="825.0,400.1 808.5,428.7 775.5,428.7 759.0,400.1 775.5,371.5 808.5,371.5" stroke-opacity="0.28"/>
+<polygon points="874.5,200.1 858.0,228.6 825.0,228.6 808.5,200.1 825.0,171.5 858.0,171.5" stroke-opacity="0.35"/>
+<polygon points="874.5,428.7 858.0,457.3 825.0,457.3 808.5,428.7 825.0,400.1 858.0,400.1" stroke-opacity="0.22"/>
+<polygon points="973.5,200.1 957.0,228.6 924.0,228.6 907.5,200.1 924.0,171.5 957.0,171.5" stroke-opacity="0.34"/>
+<polygon points="973.5,428.7 957.0,457.3 924.0,457.3 907.5,428.7 924.0,400.1 957.0,400.1" stroke-opacity="0.50"/>
+<polygon points="1023.0,171.5 1006.5,200.1 973.5,200.1 957.0,171.5 973.5,142.9 1006.5,142.9" stroke-opacity="0.22"/>
+<polygon points="1023.0,228.6 1006.5,257.2 973.5,257.2 957.0,228.6 973.5,200.1 1006.5,200.1" stroke-opacity="0.62"/>
+<polygon points="1023.0,342.9 1006.5,371.5 973.5,371.5 957.0,342.9 973.5,314.4 1006.5,314.4" stroke-opacity="0.37"/>
+<polygon points="1023.0,400.1 1006.5,428.7 973.5,428.7 957.0,400.1 973.5,371.5 1006.5,371.5" stroke-opacity="0.22"/>
+<polygon points="1072.5,200.1 1056.0,228.6 1023.0,228.6 1006.5,200.1 1023.0,171.5 1056.0,171.5" stroke-opacity="0.42"/>
+<polygon points="1072.5,257.2 1056.0,285.8 1023.0,285.8 1006.5,257.2 1023.0,228.6 1056.0,228.6" stroke-opacity="0.59"/>
+<polygon points="1072.5,314.4 1056.0,342.9 1023.0,342.9 1006.5,314.4 1023.0,285.8 1056.0,285.8" stroke-opacity="0.26"/>
+<polygon points="1122.0,228.6 1105.5,257.2 1072.5,257.2 1056.0,228.6 1072.5,200.1 1105.5,200.1" stroke-opacity="0.23"/>
+</g>
+<g filter="url(#lift)">
+<polygon points="874.5,257.2 858.0,285.8 825.0,285.8 808.5,257.2 825.0,228.6 858.0,228.6" fill="url(#cell)" fill-opacity="0.67" stroke="#8a5a20" stroke-opacity="0.5" stroke-width="1"/>
+<polygon points="874.5,314.4 858.0,342.9 825.0,342.9 808.5,314.4 825.0,285.8 858.0,285.8" fill="url(#hot)" fill-opacity="0.69" stroke="#8a5a20" stroke-opacity="0.5" stroke-width="1"/>
+<circle cx="842" cy="310" r="3" fill="#fff3d6" opacity="0.9"/>
+<polygon points="874.5,371.5 858.0,400.1 825.0,400.1 808.5,371.5 825.0,342.9 858.0,342.9" fill="url(#cell)" fill-opacity="0.55" stroke="#8a5a20" stroke-opacity="0.5" stroke-width="1"/>
+<polygon points="924.0,228.6 907.5,257.2 874.5,257.2 858.0,228.6 874.5,200.1 907.5,200.1" fill="url(#cell)" fill-opacity="0.53" stroke="#8a5a20" stroke-opacity="0.5" stroke-width="1"/>
+<polygon points="924.0,285.8 907.5,314.4 874.5,314.4 858.0,285.8 874.5,257.2 907.5,257.2" fill="url(#hot)" fill-opacity="1.00" stroke="#8a5a20" stroke-opacity="0.5" stroke-width="1"/>
+<circle cx="891" cy="282" r="3" fill="#fff3d6" opacity="0.9"/>
+<polygon points="924.0,342.9 907.5,371.5 874.5,371.5 858.0,342.9 874.5,314.4 907.5,314.4" fill="url(#hot)" fill-opacity="0.88" stroke="#8a5a20" stroke-opacity="0.5" stroke-width="1"/>
+<circle cx="891" cy="339" r="3" fill="#fff3d6" opacity="0.9"/>
+<polygon points="924.0,400.1 907.5,428.7 874.5,428.7 858.0,400.1 874.5,371.5 907.5,371.5" fill="url(#cell)" fill-opacity="0.52" stroke="#8a5a20" stroke-opacity="0.5" stroke-width="1"/>
+<polygon points="973.5,257.2 957.0,285.8 924.0,285.8 907.5,257.2 924.0,228.6 957.0,228.6" fill="url(#hot)" fill-opacity="0.72" stroke="#8a5a20" stroke-opacity="0.5" stroke-width="1"/>
+<circle cx="940" cy="253" r="3" fill="#fff3d6" opacity="0.9"/>
+<polygon points="973.5,314.4 957.0,342.9 924.0,342.9 907.5,314.4 924.0,285.8 957.0,285.8" fill="url(#hot)" fill-opacity="0.79" stroke="#8a5a20" stroke-opacity="0.5" stroke-width="1"/>
+<circle cx="940" cy="310" r="3" fill="#fff3d6" opacity="0.9"/>
+<polygon points="973.5,371.5 957.0,400.1 924.0,400.1 907.5,371.5 924.0,342.9 957.0,342.9" fill="url(#cell)" fill-opacity="0.53" stroke="#8a5a20" stroke-opacity="0.5" stroke-width="1"/>
+<polygon points="1023.0,285.8 1006.5,314.4 973.5,314.4 957.0,285.8 973.5,257.2 1006.5,257.2" fill="url(#cell)" fill-opacity="0.57" stroke="#8a5a20" stroke-opacity="0.5" stroke-width="1"/>
+</g>
+<path d="M837,338 Q839,350 842,372" fill="none" stroke="#c78a33" stroke-width="1.7" stroke-opacity="0.55" stroke-linecap="round"/>
+<circle cx="842" cy="372" r="7.8" fill="url(#halo)" filter="url(#soft)"/>
+<ellipse cx="842" cy="372" rx="3.4" ry="2.0" fill="#c8862e" stroke="#8a5a20" stroke-opacity="0.5" stroke-width="0.6" transform="rotate(82 842 372)"/>
+<circle cx="840.5" cy="370.5" r="1.4" fill="#fff3d6"/>
+<path d="M858,237 Q874,228 891,229" fill="none" stroke="#c78a33" stroke-width="1.7" stroke-opacity="0.55" stroke-linecap="round"/>
+<circle cx="891" cy="229" r="7.8" fill="url(#halo)" filter="url(#soft)"/>
+<ellipse cx="891" cy="229" rx="3.4" ry="2.0" fill="#c8862e" stroke="#8a5a20" stroke-opacity="0.5" stroke-width="0.6" transform="rotate(346 891 229)"/>
+<circle cx="890.0" cy="227.6" r="1.4" fill="#fff3d6"/>
+<path d="M966,262 Q978,269 990,286" fill="none" stroke="#c78a33" stroke-width="1.7" stroke-opacity="0.55" stroke-linecap="round"/>
+<circle cx="990" cy="286" r="7.8" fill="url(#halo)" filter="url(#soft)"/>
+<ellipse cx="990" cy="286" rx="3.4" ry="2.0" fill="#c8862e" stroke="#8a5a20" stroke-opacity="0.5" stroke-width="0.6" transform="rotate(45 990 286)"/>
+<circle cx="989.0" cy="284.8" r="1.4" fill="#fff3d6"/>
+<line x1="120" y1="540" x2="470" y2="540" stroke="#a86f2a" stroke-opacity="0.3" stroke-width="1.5"/>
+<g filter="url(#lift)"><rect x="205" y="372" width="210" height="138" rx="10" fill="#fffaf0" stroke="#c99236" stroke-opacity="0.6" stroke-width="1.2"/></g>
+<rect x="217" y="384" width="186" height="114" rx="6" fill="url(#screen)"/>
+<path d="M284,510 l52,0 l14,26 l-80,0 z" fill="#c99236" opacity="0.7"/>
+<rect x="229" y="406" width="110" height="6" rx="3" fill="#6a4a1e" opacity="0.70"/>
+<rect x="229" y="430" width="68" height="6" rx="3" fill="#6a4a1e" opacity="0.62"/>
+<rect x="229" y="454" width="79" height="6" rx="3" fill="#6a4a1e" opacity="0.54"/>
+<rect x="229" y="478" width="131" height="6" rx="3" fill="#6a4a1e" opacity="0.46"/>
+<rect x="229" y="502" width="14" height="8" rx="2" fill="#6a4a1e" opacity="0.85"/>
+<path d="M398,390 Q406,377 414,372" fill="none" stroke="#c78a33" stroke-width="2.0" stroke-opacity="0.55" stroke-linecap="round"/>
+<circle cx="414" cy="372" r="9.1" fill="url(#halo)" filter="url(#soft)"/>
+<ellipse cx="414" cy="372" rx="6.0" ry="2.2" fill="#e7a94c" opacity="0.30" transform="rotate(-87 414 372)"/>
+<ellipse cx="414" cy="372" rx="6.0" ry="2.2" fill="#e7a94c" opacity="0.30" transform="rotate(-11 414 372)"/>
+<ellipse cx="414" cy="372" rx="4.0" ry="2.4" fill="#c8862e" stroke="#8a5a20" stroke-opacity="0.5" stroke-width="0.6" transform="rotate(-49 414 372)"/>
+<circle cx="412.3" cy="370.5" r="1.6" fill="#fff3d6"/>
+<path d="M429,355 Q438,342 447,337" fill="none" stroke="#c78a33" stroke-width="2.2" stroke-opacity="0.55" stroke-linecap="round"/>
+<circle cx="447" cy="337" r="10.1" fill="url(#halo)" filter="url(#soft)"/>
+<ellipse cx="447" cy="337" rx="6.6" ry="2.4" fill="#e7a94c" opacity="0.30" transform="rotate(-83 447 337)"/>
+<ellipse cx="447" cy="337" rx="6.6" ry="2.4" fill="#e7a94c" opacity="0.30" transform="rotate(-7 447 337)"/>
+<ellipse cx="447" cy="337" rx="4.4" ry="2.6" fill="#c8862e" stroke="#8a5a20" stroke-opacity="0.5" stroke-width="0.6" transform="rotate(-45 447 337)"/>
+<circle cx="445.9" cy="335.4" r="1.8" fill="#fff3d6"/>
+<path d="M455,323 Q466,310 477,305" fill="none" stroke="#c78a33" stroke-width="2.4" stroke-opacity="0.55" stroke-linecap="round"/>
+<circle cx="477" cy="305" r="11.0" fill="url(#halo)" filter="url(#soft)"/>
+<ellipse cx="477" cy="305" rx="7.2" ry="2.6" fill="#e7a94c" opacity="0.30" transform="rotate(-79 477 305)"/>
+<ellipse cx="477" cy="305" rx="7.2" ry="2.6" fill="#e7a94c" opacity="0.30" transform="rotate(-3 477 305)"/>
+<ellipse cx="477" cy="305" rx="4.8" ry="2.9" fill="#c8862e" stroke="#8a5a20" stroke-opacity="0.5" stroke-width="0.6" transform="rotate(-41 477 305)"/>
+<circle cx="475.1" cy="303.2" r="1.9" fill="#fff3d6"/>
+<path d="M487,298 Q499,285 512,280" fill="none" stroke="#c78a33" stroke-width="2.6" stroke-opacity="0.55" stroke-linecap="round"/>
+<circle cx="512" cy="280" r="11.8" fill="url(#halo)" filter="url(#soft)"/>
+<ellipse cx="512" cy="280" rx="7.7" ry="2.8" fill="#e7a94c" opacity="0.30" transform="rotate(-73 512 280)"/>
+<ellipse cx="512" cy="280" rx="7.7" ry="2.8" fill="#e7a94c" opacity="0.30" transform="rotate(3 512 280)"/>
+<ellipse cx="512" cy="280" rx="5.1" ry="3.1" fill="#c8862e" stroke="#8a5a20" stroke-opacity="0.5" stroke-width="0.6" transform="rotate(-35 512 280)"/>
+<circle cx="510.4" cy="278.6" r="2.1" fill="#fff3d6"/>
+<path d="M500,276 Q515,264 529,261" fill="none" stroke="#c78a33" stroke-width="2.7" stroke-opacity="0.55" stroke-linecap="round"/>
+<circle cx="529" cy="261" r="12.4" fill="url(#halo)" filter="url(#soft)"/>
+<ellipse cx="529" cy="261" rx="8.1" ry="3.0" fill="#e7a94c" opacity="0.30" transform="rotate(-67 529 261)"/>
+<ellipse cx="529" cy="261" rx="8.1" ry="3.0" fill="#e7a94c" opacity="0.30" transform="rotate(9 529 261)"/>
+<ellipse cx="529" cy="261" rx="5.4" ry="3.2" fill="#c8862e" stroke="#8a5a20" stroke-opacity="0.5" stroke-width="0.6" transform="rotate(-29 529 261)"/>
+<circle cx="527.1" cy="258.9" r="2.2" fill="#fff3d6"/>
+<path d="M527,267 Q542,256 558,254" fill="none" stroke="#c78a33" stroke-width="2.8" stroke-opacity="0.55" stroke-linecap="round"/>
+<circle cx="558" cy="254" r="12.9" fill="url(#halo)" filter="url(#soft)"/>
+<ellipse cx="558" cy="254" rx="8.4" ry="3.1" fill="#e7a94c" opacity="0.30" transform="rotate(-60 558 254)"/>
+<ellipse cx="558" cy="254" rx="8.4" ry="3.1" fill="#e7a94c" opacity="0.30" transform="rotate(16 558 254)"/>
+<ellipse cx="558" cy="254" rx="5.6" ry="3.4" fill="#c8862e" stroke="#8a5a20" stroke-opacity="0.5" stroke-width="0.6" transform="rotate(-22 558 254)"/>
+<circle cx="556.3" cy="252.7" r="2.2" fill="#fff3d6"/>
+<path d="M566,253 Q583,244 599,244" fill="none" stroke="#c78a33" stroke-width="2.9" stroke-opacity="0.55" stroke-linecap="round"/>
+<circle cx="599" cy="244" r="13.2" fill="url(#halo)" filter="url(#soft)"/>
+<ellipse cx="599" cy="244" rx="8.6" ry="3.2" fill="#e7a94c" opacity="0.30" transform="rotate(-52 599 244)"/>
+<ellipse cx="599" cy="244" rx="8.6" ry="3.2" fill="#e7a94c" opacity="0.30" transform="rotate(24 599 244)"/>
+<ellipse cx="599" cy="244" rx="5.8" ry="3.5" fill="#c8862e" stroke="#8a5a20" stroke-opacity="0.5" stroke-width="0.6" transform="rotate(-14 599 244)"/>
+<circle cx="597.6" cy="242.6" r="2.3" fill="#fff3d6"/>
+<path d="M578,240 Q595,234 612,237" fill="none" stroke="#c78a33" stroke-width="2.9" stroke-opacity="0.55" stroke-linecap="round"/>
+<circle cx="612" cy="237" r="13.3" fill="url(#halo)" filter="url(#soft)"/>
+<ellipse cx="612" cy="237" rx="8.7" ry="3.2" fill="#e7a94c" opacity="0.30" transform="rotate(-44 612 237)"/>
+<ellipse cx="612" cy="237" rx="8.7" ry="3.2" fill="#e7a94c" opacity="0.30" transform="rotate(32 612 237)"/>
+<ellipse cx="612" cy="237" rx="5.8" ry="3.5" fill="#c8862e" stroke="#8a5a20" stroke-opacity="0.5" stroke-width="0.6" transform="rotate(-6 612 237)"/>
+<circle cx="610.5" cy="234.9" r="2.3" fill="#fff3d6"/>
+<path d="M624,230 Q641,226 658,232" fill="none" stroke="#c78a33" stroke-width="2.9" stroke-opacity="0.55" stroke-linecap="round"/>
+<circle cx="658" cy="232" r="13.2" fill="url(#halo)" filter="url(#soft)"/>
+<ellipse cx="658" cy="232" rx="8.6" ry="3.2" fill="#e7a94c" opacity="0.30" transform="rotate(-35 658 232)"/>
+<ellipse cx="658" cy="232" rx="8.6" ry="3.2" fill="#e7a94c" opacity="0.30" transform="rotate(41 658 232)"/>
+<ellipse cx="658" cy="232" rx="5.8" ry="3.5" fill="#c8862e" stroke="#8a5a20" stroke-opacity="0.5" stroke-width="0.6" transform="rotate(3 658 232)"/>
+<circle cx="656.8" cy="230.1" r="2.3" fill="#fff3d6"/>
+<path d="M647,235 Q663,234 680,242" fill="none" stroke="#c78a33" stroke-width="2.8" stroke-opacity="0.55" stroke-linecap="round"/>
+<circle cx="680" cy="242" r="12.9" fill="url(#halo)" filter="url(#soft)"/>
+<ellipse cx="680" cy="242" rx="8.4" ry="3.1" fill="#e7a94c" opacity="0.30" transform="rotate(-27 680 242)"/>
+<ellipse cx="680" cy="242" rx="8.4" ry="3.1" fill="#e7a94c" opacity="0.30" transform="rotate(49 680 242)"/>
+<ellipse cx="680" cy="242" rx="5.6" ry="3.4" fill="#c8862e" stroke="#8a5a20" stroke-opacity="0.5" stroke-width="0.6" transform="rotate(11 680 242)"/>
+<circle cx="678.0" cy="239.9" r="2.2" fill="#fff3d6"/>
+<path d="M679,238 Q694,239 709,249" fill="none" stroke="#c78a33" stroke-width="2.7" stroke-opacity="0.55" stroke-linecap="round"/>
+<circle cx="709" cy="249" r="12.4" fill="url(#halo)" filter="url(#soft)"/>
+<ellipse cx="709" cy="249" rx="8.1" ry="3.0" fill="#e7a94c" opacity="0.30" transform="rotate(-19 709 249)"/>
+<ellipse cx="709" cy="249" rx="8.1" ry="3.0" fill="#e7a94c" opacity="0.30" transform="rotate(57 709 249)"/>
+<ellipse cx="709" cy="249" rx="5.4" ry="3.2" fill="#c8862e" stroke="#8a5a20" stroke-opacity="0.5" stroke-width="0.6" transform="rotate(19 709 249)"/>
+<circle cx="707.6" cy="246.9" r="2.2" fill="#fff3d6"/>
+<path d="M711,250 Q725,253 738,264" fill="none" stroke="#c78a33" stroke-width="2.6" stroke-opacity="0.55" stroke-linecap="round"/>
+<circle cx="738" cy="264" r="11.8" fill="url(#halo)" filter="url(#soft)"/>
+<ellipse cx="738" cy="264" rx="7.7" ry="2.8" fill="#e7a94c" opacity="0.30" transform="rotate(-12 738 264)"/>
+<ellipse cx="738" cy="264" rx="7.7" ry="2.8" fill="#e7a94c" opacity="0.30" transform="rotate(64 738 264)"/>
+<ellipse cx="738" cy="264" rx="5.1" ry="3.1" fill="#c8862e" stroke="#8a5a20" stroke-opacity="0.5" stroke-width="0.6" transform="rotate(26 738 264)"/>
+<circle cx="737.0" cy="262.2" r="2.1" fill="#fff3d6"/>
+<path d="M742,273 Q754,276 766,288" fill="none" stroke="#c78a33" stroke-width="2.4" stroke-opacity="0.55" stroke-linecap="round"/>
+<circle cx="766" cy="288" r="11.0" fill="url(#halo)" filter="url(#soft)"/>
+<ellipse cx="766" cy="288" rx="7.2" ry="2.6" fill="#e7a94c" opacity="0.30" transform="rotate(-5 766 288)"/>
+<ellipse cx="766" cy="288" rx="7.2" ry="2.6" fill="#e7a94c" opacity="0.30" transform="rotate(71 766 288)"/>
+<ellipse cx="766" cy="288" rx="4.8" ry="2.9" fill="#c8862e" stroke="#8a5a20" stroke-opacity="0.5" stroke-width="0.6" transform="rotate(33 766 288)"/>
+<circle cx="764.9" cy="286.8" r="1.9" fill="#fff3d6"/>
+<path d="M773,277 Q783,282 794,294" fill="none" stroke="#c78a33" stroke-width="2.2" stroke-opacity="0.55" stroke-linecap="round"/>
+<circle cx="794" cy="294" r="10.1" fill="url(#halo)" filter="url(#soft)"/>
+<ellipse cx="794" cy="294" rx="6.6" ry="2.4" fill="#e7a94c" opacity="0.30" transform="rotate(1 794 294)"/>
+<ellipse cx="794" cy="294" rx="6.6" ry="2.4" fill="#e7a94c" opacity="0.30" transform="rotate(77 794 294)"/>
+<ellipse cx="794" cy="294" rx="4.4" ry="2.6" fill="#c8862e" stroke="#8a5a20" stroke-opacity="0.5" stroke-width="0.6" transform="rotate(39 794 294)"/>
+<circle cx="792.3" cy="292.4" r="1.8" fill="#fff3d6"/>
+<path d="M795,318 Q803,323 812,335" fill="none" stroke="#c78a33" stroke-width="2.0" stroke-opacity="0.55" stroke-linecap="round"/>
+<circle cx="812" cy="335" r="9.1" fill="url(#halo)" filter="url(#soft)"/>
+<ellipse cx="812" cy="335" rx="6.0" ry="2.2" fill="#e7a94c" opacity="0.30" transform="rotate(5 812 335)"/>
+<ellipse cx="812" cy="335" rx="6.0" ry="2.2" fill="#e7a94c" opacity="0.30" transform="rotate(81 812 335)"/>
+<ellipse cx="812" cy="335" rx="4.0" ry="2.4" fill="#c8862e" stroke="#8a5a20" stroke-opacity="0.5" stroke-width="0.6" transform="rotate(43 812 335)"/>
+<circle cx="810.8" cy="333.6" r="1.6" fill="#fff3d6"/>
+<circle cx="443" cy="148" r="1.9" fill="#d59a44" opacity="0.37"/>
+<circle cx="592" cy="422" r="1.3" fill="#d59a44" opacity="0.31"/>
+<circle cx="684" cy="124" r="1.8" fill="#d59a44" opacity="0.23"/>
+<circle cx="568" cy="351" r="1.9" fill="#d59a44" opacity="0.45"/>
+<circle cx="452" cy="149" r="1.2" fill="#d59a44" opacity="0.36"/>
+<circle cx="456" cy="99" r="1.9" fill="#d59a44" opacity="0.35"/>
+<circle cx="575" cy="158" r="1.2" fill="#d59a44" opacity="0.20"/>
+<circle cx="353" cy="177" r="1.4" fill="#d59a44" opacity="0.31"/>
+<circle cx="657" cy="427" r="1.2" fill="#d59a44" opacity="0.32"/>
+<circle cx="243" cy="335" r="2.0" fill="#d59a44" opacity="0.26"/>
+<circle cx="615" cy="190" r="1.0" fill="#d59a44" opacity="0.43"/>
+<circle cx="352" cy="138" r="1.4" fill="#d59a44" opacity="0.27"/>
+<rect width="1200" height="675" fill="url(#vig)"/>
+<rect width="1200" height="675" filter="url(#grain)" opacity="0.04"/>
+<text x="60" y="622" font-family="Mo" font-size="12" letter-spacing="3" fill="#9a6a2c" fill-opacity="0.8">FIELD NOTES</text>
+<text x="1140" y="622" text-anchor="end" font-family="Mo" font-size="12" letter-spacing="2" fill="#9a6a2c" fill-opacity="0.55">01 / 06</text>
+</svg>

--- a/beta/public/images/blog/ki-agenten-betriebssystem.svg
+++ b/beta/public/images/blog/ki-agenten-betriebssystem.svg
@@ -1,0 +1,207 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 675" width="1200" height="675" role="img" aria-label="Konzept C: Feature-Requests fliessen aus einem Terminal, Agenten bauen daraus das System">
+<defs>
+<style>@font-face{font-family:'Mo';src:url(data:font/woff2;base64,d09GMgABAAAAAA7QAA8AAAAAHEwAAA53AAGzMwAAAAAAAAAAAAAAAAAAAAAAAAAAGigbIBwqBmA/U1RBVEgAgX4RCAqsLKJ4ATYCJAOCTguBKgAEIAVmByAb5RWjolZyVsaI/uKAJ0MfBYTACKR2WmgcqlNCrcK+9m3czlmg3OwcHiCxvo6QZPbncdv/GWET8qJtEERBQImSHOxSEy4D5oysF+n7WcHPCHmA7t3721fDDjigCbQtoDzwkMOAozGBw67/AcA5+31rZVXPhOpPB4AUsDtw9+LTsEznE561Gxt1gDZhjaQWB8+J0MAycHtU/O9aafMPyBVQIQrZs301proS/yazu8nm/l7miHgKQG6riFzVTAFIWJa1FfKUqxCyklRf5gzEKs6tRLzvreZMHlPkAjmAW1N4Du46AgGgyKk1jwChGpTK4D5GrWGMkYPXe9kCO5Ug5nNhDHkEAGAdmFjlMxWUeFcn3hdnxmBrLQA3QZrmkxSAd/QqCCC0mIfYkT5xVvASyK94+l74Tq/FLLxheEgIG/nf/d9CMOZjFN8MeDUvC5TJMbV9Hh6AjXdWVXaoD8xUE/+FsQk5KkEN+IxnJye9uSdiRRhSOCO4ilwNdTXBxgh8/TFrlBEoUEZFy8LKLSaJNWvJnc4urh6+fv4NG9fXAZRRqlUPa+5BY3SaU0pzLwCx4viQUqUOeQCcbOwYK62ceZuJByicVqLMx0aiKBElypSrUKmKnEI1FbVadTS0dPQMGhiZEIiIBAAAnsJV3v0gZ0uQ3wOAFQMcgOL1ivAhjlwQn/HSiTz8pMi5AEJMxSRQY3men2qBU0UMz7qKfQw4lnx6r0ogy88vKcwvKqyWFhULrmfPlRZJpaJ8gbR4S74uT5YnLcovqC7aIi6xLltziwTloi0iSRG3qN4qLdosXnps06qLBJtyRV9NgeBbz0JBhbaQL68Qt2MP/nIEuYLLlsmWZ9QE8shKLuO9ttiCZy/Fz1CY+dyIS0z7uftJACYXe9/Y/iedxprdSK/bUKx8ZeOtFAKsebAp5io0RXQV2J5VenvFaaPzm0zOCUOJu7Am0EPN6KkAoQTTowa89RHWJCGIR7rzTQwHZt748VxHozbUqbvVQRbmUjmn67cgK3mmMunc5v4tfnHrUKiD32TpDJ8HdRnpTLGoIACnTiHpiLvY5wJ+9NbB0chacSv6Lxehu16fy2+ZCD92Y3/olTmCVH7KSEFbvUV4F4nJwtURVqcj5xxlmMBMHpVBOoVkGomkpBI6wLdU4HbEmhqarA39ve9+0juOO9mPJooBQM+h9MK7k1g6QtKazfdEvK41/ZOHjJwR6uhi7jdUwZnDq3lnzEa+JmNzztm1jpGleR+Gh19qljughLpWO3nkE0VeMqfscHpK1zDYUssByGubUJhiTdUnn/TL62V+5hePkNMus4fMMLVm+U3ui2IL1MHVOl9JYHiI4soOpnVLBRKxXDU5xywqC+NHmqC8iUmKM9S9pZt1h7qXwgJHdDnswU3Q8hAimT+AvjmKagdZvZWidvQCZyj5LGQpqe+LtAT/QOWDnTsvwf9zuHzm9f0eCX+WgTHlWgXswYnnFhreUDOYetavvyVd/ndO0Vd48OiEWcj+Sm+hmP25PRp90SADQaHPzzdHf2gVGBiyqjHSVzBJR+l1pQDVWFPU1obCB4Yzj0mdeYh1nqQSrTbJ+jRnXkKFOHZTqrVZWgRcb72sciG+biu29/Ieg3tdfM0ISQqtJf7f/v6w/d+W/YwjGvOf9GEt/aNJ6jeHMuZv3t7uePVMwz2yjiOuI14iqaSDUAotbndJ0pqixMHF/R8xEP2BzpG4cuUNzcW42HRfEiZz7dXwIiKf4I/8dfsQd45FzvZpTG3B6UMxMHH5PH7iL7Qasj3U2swLBlkvLmTsQ9zzrIkqdlFxXDnPY2iaGNRSJoRMhzFK5U/enLOSo5Mf3nvmyeFun1c10qd2JcTwxwNs9snZuX62VuUPVetznGmVJtTA7RmcPCZxXCRoM1pCTeg4PIe8lkaj14LmoE6SnM3YL5+atl8+yybbDixtGm0RSsPxiNkS9lTv5Vqq94Q9FmcyKcasQDZz6CCw2au4tTi6YGoKnb/WzDUnIgNTh48cmVobiACbvQmzn0Xj0S+6MPRk74ofs7CNjtN6UElCM3HvZUvTzstn2YS7x+LtE3syQqk7mmgyRTzKvVyLak/UYzEEG1RtO6+J/91P86+cf7k+Fq4Fe5bJ3HzczRkmy7TK/q1A45tLbsZ3Lb4BkEnIfpt1jECJXF6SSiCEcPJN5s251SNw5KMZw/jQV49nmWzDH/33yy+HnixzwbXHYxDGDsnz5pjs/mMDSnzg/iwzl3dIDmR2qWDt4+OYresnx4NagmeS9svnFghZY5y0MHePRMIUdlXvaW2t3ht2m3zpRh/IPTk3YLNvolGDrcPnI5TPhPZvHFjAMZ/LHfPiBVie20czy+Fd3sf3WlS/qoObB8k5I38xE/smuvV14YA6biP5pE3oLX6GkT5UtubRnFYytR9FPA5nxI32g1ESmnb4R4SBjLBHQyG5Xu/dWlZZ8SGuiW+mNrJ6ZbDRbmYH9RTVb7X35royQlbuccvrPRGnofxpqswjY7b02WqbbWYHM6oFYuotnIffmgK1ZGLP8UvPM8+noy2hEKm0K5cyPeDX0ePc/cdvfSTnuMFI5HHWfWpBxMuBLADJhiX7Ke1W7An6R3se7Og5ZadapuvBzke7e84oWwZ4FW9d2nVxyLPrjUsrQM8cu2MJv31+B6dh+KxQH6usc6l9NGKkN1f67G6L6cX70zliNMGxHYNTve/K/pNWIPqkoorPJnKknWSsRE4ZA1WVnlrNxaWZs8rlSggX1vh3bHz0ecF8OIsVB9d+8JfWkL1e43IyaZB/kijmDQ+2cOEBt86vqUo57VVpnxYshWjUa1vB2LY86kO2lhpb8zUp4W2k2UDFBzguPkAZkO3elPAaB9OqhYJCjv/wpNpX+sPaQQXOhgXzz99a5d9RFav3aavSdmdVyq/RucMDXEt4EHSFoRGvdQVj6/KQj/IPumzLmW37BZhO+hs89U9kcjaSM+z3PoUwHAnYHFEErzYEgih0DbqmNKe84aMn0CMIlBdbWuQO//Up4W1PO4Jhi5VRJXQN3gG3dToUtkz1uT3mtGEHpr93mtL9GiTyNbdBc05V1FejIcNt8Xi0DXqyWHXyuX/4t6ssUb2StSWxI2KkzK5wBNmBRq9dufYrKn3yTnQnhtHT0VXVnfXfrG1CLhkVCNPAZvFLxM6JFz98u77v+j/6R48B6a7tZYayVbSPQojaqNyFPkSglEV4sycfY/VptHqv0F1wvDNQ77Kk+jowDrxZtulvVV0cY98z5XsbcPcHHz7rgjC1S+WgG1WsOYkdyBK2q9wVCo/OAepCauTZsCRyiMLTlpPYttIyGKPoAY4joibPArHTr4oS87c7uCZHrCeiXaUoQLhXTEXuIPbdn3f6W/5of2srjJZf41FXpdzuypRXDbmn47z79xHkDlUTNyfXVHc7MR/96jltL1TigUwa+m8FsOjWIy+s3YpezD1+Ntfn9VhGwyPV0XtqS+ZfRNBY6O/WmmldSjhBmppsrvKqLa23nR0WMUqHWlMXyKjcnrTGEF5NCVsKglXW1YodF57yR3NRRmmr1Ro9bZVA/+5t7OxocHeN9sZ9SYYUwC2sTp8wth0YXnDRrhh2uGqGwiXW2lit09/UqL3HaQ8E3b/DUiQUQP/if+WyyhPQa0+g1xHkFMZah9qS2BkxBi3OAB2wYxl9ICtxZUj443sxd/69t+QwB1YH/Brf3ZHx+INvC66/eMgfWZ4FjI9I7iK6jnniyBM9d/If0l2nvCbeF46cjhw7L+oq3/VYLnfR3Wfczb2Ov76zEeI4Nk2iS5aeaQTzvVv+i/HNst2TkYmM7fKp6RYTbCQ6zrKZngK38UwkoSf9ir2pjEDI1esCfkImhfD/BnaK70Edis9iSjJrxB9i0Ic0C3Ojg6b8e2+ukv/+gzbERAoCGWFh/5HlaarfYOQcxsoo9lKKnxh/rWv7MRjkkunlMUEqLRS6sMmlDm39sl57XnCnxozN8tdcSpPf7PH6GscywvzYfFe/v1djTNo8cZoWy5j83v6oz90+rYOD53DR5Hvcmwxmzsl8J+gAlcTfp7NnUEa4HLU7/HEc0lcGPQptTVgp5DQnLGF1qXD9f9Onpb4+p3k0EHCMjTigTkJPBK3H96Z3nu2aGfLEmlIqY+ilTO7dF9tsCY/mENGz4dIRuspA9tssI1TUOTFmDyTIZDqG6KS3PqRQB3Q6RShQAw+N2d+efC7K7scfRj2hjtMdZ+26hAW1hJzUulv9kZaeUPGGh1DYYzalOvRNTZ16Y8rsocIvbggXsz0Rv7t1QksmyIzL64whOkYjpzfj8nMWn9li8NhsVq/NAHmgek3fFR/Xtxo3W23YUzdm3E6umqIpmnnO75dWluCHixsvNi4tTNiuheHRDXyOpmeF+X9iAzHY8G+0PgrdoxEfPqHsJIoSKH2yByITJ5afEAxij8QJKAC/zGOLnj8n4kRE4vqt4aqernQXQ2mwPuXvP4AYkwtxdVuUXJp8C5SwnNCPJK3ESYldMTVR7dHapDjEmKL+0pQgRmUQ+9l7wS+nwbWPcO3dC1sBYDsAz8lfBsX6jzy9ADvs9Dau/8pT8J4gGoBXL6aPrQ/xXcqahxLJQiLxZ8n3AMSu/gX4RY869bLErYaidWdtu8T+Wx6f/yUBwGfpa1Jws1+l//9l/H+Od4KgAsK891bWuzHDS1cT/rtPkBynmgTxKz1mwvYrsKCIZaknDXagSYmhB/RElm+voAK5XW1dAVRyBT0pgYwALJH51IQDKoiexo4RWwZKwGQFokUSix1pYgE2ghEaKJ5HdhbWm7upfAD4nn6c8CuM0ILI0EUwWjHg6gQQAHDypxqDihBOmp/OEzCiAXk+8IgBXowAKCIGeex2rXiLes+4Xv1mjeg0JWVXg9ZrwAzKjE4jonW3uHGjEB57Tzp5fY1OBoQT) format('woff2');}</style>
+<radialGradient id="ground" cx="30%" cy="64%" r="80%">
+  <stop offset="0%" stop-color="#1c1610"/><stop offset="55%" stop-color="#120e0a"/>
+  <stop offset="100%" stop-color="#090705"/>
+</radialGradient>
+<radialGradient id="coreglow" cx="50%" cy="50%" r="50%">
+  <stop offset="0%" stop-color="#f5bd62" stop-opacity="0.52"/>
+  <stop offset="45%" stop-color="#c8863c" stop-opacity="0.20"/>
+  <stop offset="100%" stop-color="#c8863c" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="heart" cx="50%" cy="50%" r="50%">
+  <stop offset="0%" stop-color="#ffdf99" stop-opacity="0.55"/>
+  <stop offset="60%" stop-color="#f0ab4c" stop-opacity="0.12"/>
+  <stop offset="100%" stop-color="#f0ab4c" stop-opacity="0"/>
+</radialGradient>
+<linearGradient id="cell" x1="0" y1="0" x2="0" y2="1">
+  <stop offset="0%" stop-color="#eab866"/><stop offset="52%" stop-color="#b07e40"/>
+  <stop offset="100%" stop-color="#5f4223"/>
+</linearGradient>
+<radialGradient id="hot" cx="50%" cy="42%" r="60%">
+  <stop offset="0%" stop-color="#ffe0a0"/><stop offset="55%" stop-color="#e2a24a"/>
+  <stop offset="100%" stop-color="#7a5327"/>
+</radialGradient>
+<radialGradient id="screen" cx="50%" cy="38%" r="75%">
+  <stop offset="0%" stop-color="#ffdf9c"/><stop offset="60%" stop-color="#e0a24c"/>
+  <stop offset="100%" stop-color="#9c6e34"/>
+</radialGradient>
+<radialGradient id="vig" cx="50%" cy="48%" r="62%">
+  <stop offset="60%" stop-color="#000" stop-opacity="0"/>
+  <stop offset="100%" stop-color="#050403" stop-opacity="0.74"/>
+</radialGradient>
+<filter id="glow" x="-120%" y="-120%" width="340%" height="340%"><feGaussianBlur stdDeviation="7"/></filter>
+<filter id="softbig" x="-60%" y="-60%" width="220%" height="220%"><feGaussianBlur stdDeviation="26"/></filter>
+<filter id="grain"><feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="2" stitchTiles="stitch"/>
+  <feColorMatrix type="matrix" values="0 0 0 0 0.9  0 0 0 0 0.7  0 0 0 0 0.4  0 0 0 0.5 0"/></filter>
+</defs>
+<rect width="1200" height="675" fill="url(#ground)"/>
+<ellipse cx="300" cy="440" rx="260" ry="200" fill="url(#coreglow)" filter="url(#softbig)"/>
+<ellipse cx="905" cy="300" rx="320" ry="280" fill="url(#coreglow)" filter="url(#softbig)"/>
+<ellipse cx="905" cy="300" rx="140" ry="130" fill="url(#heart)" filter="url(#softbig)"/>
+<g fill="none" stroke="#a5773f" stroke-width="1">
+<polygon points="726.0,400.1 709.5,428.7 676.5,428.7 660.0,400.1 676.5,371.5 709.5,371.5" stroke-opacity="0.07"/>
+<polygon points="775.5,142.9 759.0,171.5 726.0,171.5 709.5,142.9 726.0,114.3 759.0,114.3" stroke-opacity="0.09"/>
+<polygon points="775.5,314.4 759.0,342.9 726.0,342.9 709.5,314.4 726.0,285.8 759.0,285.8" stroke-opacity="0.13"/>
+<polygon points="775.5,371.5 759.0,400.1 726.0,400.1 709.5,371.5 726.0,342.9 759.0,342.9" stroke-opacity="0.14"/>
+<polygon points="775.5,428.7 759.0,457.3 726.0,457.3 709.5,428.7 726.0,400.1 759.0,400.1" stroke-opacity="0.15"/>
+<polygon points="825.0,114.3 808.5,142.9 775.5,142.9 759.0,114.3 775.5,85.7 808.5,85.7" stroke-opacity="0.10"/>
+<polygon points="825.0,171.5 808.5,200.1 775.5,200.1 759.0,171.5 775.5,142.9 808.5,142.9" stroke-opacity="0.11"/>
+<polygon points="825.0,457.3 808.5,485.8 775.5,485.8 759.0,457.3 775.5,428.7 808.5,428.7" stroke-opacity="0.11"/>
+<polygon points="874.5,142.9 858.0,171.5 825.0,171.5 808.5,142.9 825.0,114.3 858.0,114.3" stroke-opacity="0.08"/>
+<polygon points="924.0,171.5 907.5,200.1 874.5,200.1 858.0,171.5 874.5,142.9 907.5,142.9" stroke-opacity="0.15"/>
+<polygon points="924.0,457.3 907.5,485.8 874.5,485.8 858.0,457.3 874.5,428.7 907.5,428.7" stroke-opacity="0.12"/>
+<polygon points="973.5,85.7 957.0,114.3 924.0,114.3 907.5,85.7 924.0,57.2 957.0,57.2" stroke-opacity="0.06"/>
+<polygon points="973.5,142.9 957.0,171.5 924.0,171.5 907.5,142.9 924.0,114.3 957.0,114.3" stroke-opacity="0.10"/>
+<polygon points="1023.0,457.3 1006.5,485.8 973.5,485.8 957.0,457.3 973.5,428.7 1006.5,428.7" stroke-opacity="0.06"/>
+<polygon points="1072.5,371.5 1056.0,400.1 1023.0,400.1 1006.5,371.5 1023.0,342.9 1056.0,342.9" stroke-opacity="0.14"/>
+<polygon points="1122.0,285.8 1105.5,314.4 1072.5,314.4 1056.0,285.8 1072.5,257.2 1105.5,257.2" stroke-opacity="0.12"/>
+</g><g fill="none" stroke="#cf9a4e" stroke-width="1.1">
+<polygon points="825.0,228.6 808.5,257.2 775.5,257.2 759.0,228.6 775.5,200.1 808.5,200.1" stroke-opacity="0.15"/>
+<polygon points="825.0,285.8 808.5,314.4 775.5,314.4 759.0,285.8 775.5,257.2 808.5,257.2" stroke-opacity="0.37"/>
+<polygon points="825.0,342.9 808.5,371.5 775.5,371.5 759.0,342.9 775.5,314.4 808.5,314.4" stroke-opacity="0.41"/>
+<polygon points="825.0,400.1 808.5,428.7 775.5,428.7 759.0,400.1 775.5,371.5 808.5,371.5" stroke-opacity="0.20"/>
+<polygon points="874.5,200.1 858.0,228.6 825.0,228.6 808.5,200.1 825.0,171.5 858.0,171.5" stroke-opacity="0.28"/>
+<polygon points="874.5,428.7 858.0,457.3 825.0,457.3 808.5,428.7 825.0,400.1 858.0,400.1" stroke-opacity="0.14"/>
+<polygon points="973.5,200.1 957.0,228.6 924.0,228.6 907.5,200.1 924.0,171.5 957.0,171.5" stroke-opacity="0.27"/>
+<polygon points="973.5,428.7 957.0,457.3 924.0,457.3 907.5,428.7 924.0,400.1 957.0,400.1" stroke-opacity="0.43"/>
+<polygon points="1023.0,171.5 1006.5,200.1 973.5,200.1 957.0,171.5 973.5,142.9 1006.5,142.9" stroke-opacity="0.14"/>
+<polygon points="1023.0,228.6 1006.5,257.2 973.5,257.2 957.0,228.6 973.5,200.1 1006.5,200.1" stroke-opacity="0.56"/>
+<polygon points="1023.0,342.9 1006.5,371.5 973.5,371.5 957.0,342.9 973.5,314.4 1006.5,314.4" stroke-opacity="0.30"/>
+<polygon points="1023.0,400.1 1006.5,428.7 973.5,428.7 957.0,400.1 973.5,371.5 1006.5,371.5" stroke-opacity="0.14"/>
+<polygon points="1072.5,200.1 1056.0,228.6 1023.0,228.6 1006.5,200.1 1023.0,171.5 1056.0,171.5" stroke-opacity="0.35"/>
+<polygon points="1072.5,257.2 1056.0,285.8 1023.0,285.8 1006.5,257.2 1023.0,228.6 1056.0,228.6" stroke-opacity="0.53"/>
+<polygon points="1072.5,314.4 1056.0,342.9 1023.0,342.9 1006.5,314.4 1023.0,285.8 1056.0,285.8" stroke-opacity="0.19"/>
+<polygon points="1122.0,228.6 1105.5,257.2 1072.5,257.2 1056.0,228.6 1072.5,200.1 1105.5,200.1" stroke-opacity="0.15"/>
+</g>
+<polygon points="874.5,257.2 858.0,285.8 825.0,285.8 808.5,257.2 825.0,228.6 858.0,228.6" fill="url(#cell)" fill-opacity="0.52" stroke="#f0c479" stroke-opacity="0.30" stroke-width="1"/>
+<polygon points="874.5,314.4 858.0,342.9 825.0,342.9 808.5,314.4 825.0,285.8 858.0,285.8" fill="url(#hot)" fill-opacity="0.55" stroke="#f0c479" stroke-opacity="0.55" stroke-width="1"/>
+<circle cx="842" cy="314" r="2.4" fill="#ffe7b0" filter="url(#glow)" opacity="0.9"/>
+<polygon points="874.5,371.5 858.0,400.1 825.0,400.1 808.5,371.5 825.0,342.9 858.0,342.9" fill="url(#cell)" fill-opacity="0.38" stroke="#f0c479" stroke-opacity="0.30" stroke-width="1"/>
+<polygon points="924.0,228.6 907.5,257.2 874.5,257.2 858.0,228.6 874.5,200.1 907.5,200.1" fill="url(#cell)" fill-opacity="0.36" stroke="#f0c479" stroke-opacity="0.30" stroke-width="1"/>
+<polygon points="924.0,285.8 907.5,314.4 874.5,314.4 858.0,285.8 874.5,257.2 907.5,257.2" fill="url(#hot)" fill-opacity="0.92" stroke="#f0c479" stroke-opacity="0.55" stroke-width="1"/>
+<circle cx="891" cy="286" r="2.4" fill="#ffe7b0" filter="url(#glow)" opacity="0.9"/>
+<polygon points="924.0,342.9 907.5,371.5 874.5,371.5 858.0,342.9 874.5,314.4 907.5,314.4" fill="url(#hot)" fill-opacity="0.78" stroke="#f0c479" stroke-opacity="0.55" stroke-width="1"/>
+<circle cx="891" cy="343" r="2.4" fill="#ffe7b0" filter="url(#glow)" opacity="0.9"/>
+<polygon points="924.0,400.1 907.5,428.7 874.5,428.7 858.0,400.1 874.5,371.5 907.5,371.5" fill="url(#cell)" fill-opacity="0.35" stroke="#f0c479" stroke-opacity="0.30" stroke-width="1"/>
+<polygon points="973.5,257.2 957.0,285.8 924.0,285.8 907.5,257.2 924.0,228.6 957.0,228.6" fill="url(#hot)" fill-opacity="0.58" stroke="#f0c479" stroke-opacity="0.55" stroke-width="1"/>
+<circle cx="940" cy="257" r="2.4" fill="#ffe7b0" filter="url(#glow)" opacity="0.9"/>
+<polygon points="973.5,314.4 957.0,342.9 924.0,342.9 907.5,314.4 924.0,285.8 957.0,285.8" fill="url(#hot)" fill-opacity="0.66" stroke="#f0c479" stroke-opacity="0.55" stroke-width="1"/>
+<circle cx="940" cy="314" r="2.4" fill="#ffe7b0" filter="url(#glow)" opacity="0.9"/>
+<polygon points="973.5,371.5 957.0,400.1 924.0,400.1 907.5,371.5 924.0,342.9 957.0,342.9" fill="url(#cell)" fill-opacity="0.36" stroke="#f0c479" stroke-opacity="0.30" stroke-width="1"/>
+<polygon points="1023.0,285.8 1006.5,314.4 973.5,314.4 957.0,285.8 973.5,257.2 1006.5,257.2" fill="url(#cell)" fill-opacity="0.41" stroke="#f0c479" stroke-opacity="0.30" stroke-width="1"/>
+<path d="M838,332 Q840,346 842,372" fill="none" stroke="#ffd98f" stroke-width="1.7" stroke-opacity="0.40" stroke-linecap="round"/>
+<circle cx="842" cy="372" r="7.8" fill="#ffcf7a" opacity="0.50" filter="url(#glow)"/>
+<ellipse cx="842" cy="372" rx="3.4" ry="2.0" fill="#fff3d6" transform="rotate(85 842 372)"/>
+<path d="M859,204 Q875,211 891,229" fill="none" stroke="#ffd98f" stroke-width="1.7" stroke-opacity="0.40" stroke-linecap="round"/>
+<circle cx="891" cy="229" r="7.8" fill="#ffcf7a" opacity="0.50" filter="url(#glow)"/>
+<ellipse cx="891" cy="229" rx="3.4" ry="2.0" fill="#fff3d6" transform="rotate(37 891 229)"/>
+<path d="M1022,261 Q1006,268 990,286" fill="none" stroke="#ffd98f" stroke-width="1.7" stroke-opacity="0.40" stroke-linecap="round"/>
+<circle cx="990" cy="286" r="7.8" fill="#ffcf7a" opacity="0.50" filter="url(#glow)"/>
+<ellipse cx="990" cy="286" rx="3.4" ry="2.0" fill="#fff3d6" transform="rotate(143 990 286)"/>
+<line x1="120" y1="540" x2="470" y2="540" stroke="#c8944e" stroke-opacity="0.22" stroke-width="1.5"/>
+<circle cx="310" cy="441" r="170" fill="#f0ab4c" opacity="0.18" filter="url(#softbig)"/>
+<rect x="205" y="372" width="210" height="138" rx="10" fill="url(#screen)" stroke="#ffdca0" stroke-opacity="0.5" stroke-width="1.5"/>
+<path d="M284,510 l52,0 l14,26 l-80,0 z" fill="#7a5327" opacity="0.55"/>
+<rect x="227" y="402" width="134" height="6" rx="3" fill="#3a2a16" opacity="0.55"/>
+<rect x="227" y="428" width="134" height="6" rx="3" fill="#3a2a16" opacity="0.49"/>
+<rect x="227" y="454" width="69" height="6" rx="3" fill="#3a2a16" opacity="0.43"/>
+<rect x="227" y="480" width="71" height="6" rx="3" fill="#3a2a16" opacity="0.37"/>
+<rect x="227" y="506" width="14" height="8" rx="2" fill="#3a2a16" opacity="0.7"/>
+<path d="M398,396 Q406,384 414,378" fill="none" stroke="#ffd98f" stroke-width="2.0" stroke-opacity="0.24" stroke-linecap="round"/>
+<circle cx="414" cy="378" r="9.1" fill="#ffcf7a" opacity="0.30" filter="url(#glow)"/>
+<ellipse cx="414" cy="378" rx="6.0" ry="2.2" fill="#ffe9c4" opacity="0.11" transform="rotate(-87 414 378)"/>
+<ellipse cx="414" cy="378" rx="6.0" ry="2.2" fill="#ffe9c4" opacity="0.11" transform="rotate(-11 414 378)"/>
+<ellipse cx="414" cy="378" rx="4.0" ry="2.4" fill="#fff3d6" transform="rotate(-49 414 378)"/>
+<path d="M422,360 Q431,347 441,342" fill="none" stroke="#ffd98f" stroke-width="2.2" stroke-opacity="0.28" stroke-linecap="round"/>
+<circle cx="441" cy="342" r="10.1" fill="#ffcf7a" opacity="0.34" filter="url(#glow)"/>
+<ellipse cx="441" cy="342" rx="6.6" ry="2.4" fill="#ffe9c4" opacity="0.12" transform="rotate(-83 441 342)"/>
+<ellipse cx="441" cy="342" rx="6.6" ry="2.4" fill="#ffe9c4" opacity="0.12" transform="rotate(-7 441 342)"/>
+<ellipse cx="441" cy="342" rx="4.4" ry="2.6" fill="#fff3d6" transform="rotate(-45 441 342)"/>
+<path d="M447,324 Q458,311 468,306" fill="none" stroke="#ffd98f" stroke-width="2.4" stroke-opacity="0.31" stroke-linecap="round"/>
+<circle cx="468" cy="306" r="11.0" fill="#ffcf7a" opacity="0.39" filter="url(#glow)"/>
+<ellipse cx="468" cy="306" rx="7.2" ry="2.6" fill="#ffe9c4" opacity="0.14" transform="rotate(-79 468 306)"/>
+<ellipse cx="468" cy="306" rx="7.2" ry="2.6" fill="#ffe9c4" opacity="0.14" transform="rotate(-3 468 306)"/>
+<ellipse cx="468" cy="306" rx="4.8" ry="2.9" fill="#fff3d6" transform="rotate(-41 468 306)"/>
+<path d="M490,300 Q503,287 515,283" fill="none" stroke="#ffd98f" stroke-width="2.6" stroke-opacity="0.34" stroke-linecap="round"/>
+<circle cx="515" cy="283" r="11.8" fill="#ffcf7a" opacity="0.43" filter="url(#glow)"/>
+<ellipse cx="515" cy="283" rx="7.7" ry="2.8" fill="#ffe9c4" opacity="0.15" transform="rotate(-73 515 283)"/>
+<ellipse cx="515" cy="283" rx="7.7" ry="2.8" fill="#ffe9c4" opacity="0.15" transform="rotate(3 515 283)"/>
+<ellipse cx="515" cy="283" rx="5.1" ry="3.1" fill="#fff3d6" transform="rotate(-35 515 283)"/>
+<path d="M509,285 Q523,273 537,269" fill="none" stroke="#ffd98f" stroke-width="2.7" stroke-opacity="0.37" stroke-linecap="round"/>
+<circle cx="537" cy="269" r="12.4" fill="#ffcf7a" opacity="0.46" filter="url(#glow)"/>
+<ellipse cx="537" cy="269" rx="8.1" ry="3.0" fill="#ffe9c4" opacity="0.16" transform="rotate(-67 537 269)"/>
+<ellipse cx="537" cy="269" rx="8.1" ry="3.0" fill="#ffe9c4" opacity="0.16" transform="rotate(9 537 269)"/>
+<ellipse cx="537" cy="269" rx="5.4" ry="3.2" fill="#fff3d6" transform="rotate(-29 537 269)"/>
+<path d="M530,269 Q546,258 562,256" fill="none" stroke="#ffd98f" stroke-width="2.8" stroke-opacity="0.38" stroke-linecap="round"/>
+<circle cx="562" cy="256" r="12.9" fill="#ffcf7a" opacity="0.48" filter="url(#glow)"/>
+<ellipse cx="562" cy="256" rx="8.4" ry="3.1" fill="#ffe9c4" opacity="0.17" transform="rotate(-60 562 256)"/>
+<ellipse cx="562" cy="256" rx="8.4" ry="3.1" fill="#ffe9c4" opacity="0.17" transform="rotate(16 562 256)"/>
+<ellipse cx="562" cy="256" rx="5.6" ry="3.4" fill="#fff3d6" transform="rotate(-22 562 256)"/>
+<path d="M552,262 Q568,253 585,253" fill="none" stroke="#ffd98f" stroke-width="2.9" stroke-opacity="0.40" stroke-linecap="round"/>
+<circle cx="585" cy="253" r="13.2" fill="#ffcf7a" opacity="0.50" filter="url(#glow)"/>
+<ellipse cx="585" cy="253" rx="8.6" ry="3.2" fill="#ffe9c4" opacity="0.18" transform="rotate(-52 585 253)"/>
+<ellipse cx="585" cy="253" rx="8.6" ry="3.2" fill="#ffe9c4" opacity="0.18" transform="rotate(24 585 253)"/>
+<ellipse cx="585" cy="253" rx="5.8" ry="3.5" fill="#fff3d6" transform="rotate(-14 585 253)"/>
+<path d="M577,240 Q594,233 612,236" fill="none" stroke="#ffd98f" stroke-width="2.9" stroke-opacity="0.40" stroke-linecap="round"/>
+<circle cx="612" cy="236" r="13.3" fill="#ffcf7a" opacity="0.50" filter="url(#glow)"/>
+<ellipse cx="612" cy="236" rx="8.7" ry="3.2" fill="#ffe9c4" opacity="0.18" transform="rotate(-44 612 236)"/>
+<ellipse cx="612" cy="236" rx="8.7" ry="3.2" fill="#ffe9c4" opacity="0.18" transform="rotate(32 612 236)"/>
+<ellipse cx="612" cy="236" rx="5.8" ry="3.5" fill="#fff3d6" transform="rotate(-6 612 236)"/>
+<path d="M605,234 Q622,230 639,236" fill="none" stroke="#ffd98f" stroke-width="2.9" stroke-opacity="0.40" stroke-linecap="round"/>
+<circle cx="639" cy="236" r="13.2" fill="#ffcf7a" opacity="0.50" filter="url(#glow)"/>
+<ellipse cx="639" cy="236" rx="8.6" ry="3.2" fill="#ffe9c4" opacity="0.18" transform="rotate(-35 639 236)"/>
+<ellipse cx="639" cy="236" rx="8.6" ry="3.2" fill="#ffe9c4" opacity="0.18" transform="rotate(41 639 236)"/>
+<ellipse cx="639" cy="236" rx="5.8" ry="3.5" fill="#fff3d6" transform="rotate(3 639 236)"/>
+<path d="M642,246 Q659,244 675,252" fill="none" stroke="#ffd98f" stroke-width="2.8" stroke-opacity="0.38" stroke-linecap="round"/>
+<circle cx="675" cy="252" r="12.9" fill="#ffcf7a" opacity="0.48" filter="url(#glow)"/>
+<ellipse cx="675" cy="252" rx="8.4" ry="3.1" fill="#ffe9c4" opacity="0.17" transform="rotate(-27 675 252)"/>
+<ellipse cx="675" cy="252" rx="8.4" ry="3.1" fill="#ffe9c4" opacity="0.17" transform="rotate(49 675 252)"/>
+<ellipse cx="675" cy="252" rx="5.6" ry="3.4" fill="#fff3d6" transform="rotate(11 675 252)"/>
+<path d="M673,233 Q688,234 704,244" fill="none" stroke="#ffd98f" stroke-width="2.7" stroke-opacity="0.37" stroke-linecap="round"/>
+<circle cx="704" cy="244" r="12.4" fill="#ffcf7a" opacity="0.46" filter="url(#glow)"/>
+<ellipse cx="704" cy="244" rx="8.1" ry="3.0" fill="#ffe9c4" opacity="0.16" transform="rotate(-19 704 244)"/>
+<ellipse cx="704" cy="244" rx="8.1" ry="3.0" fill="#ffe9c4" opacity="0.16" transform="rotate(57 704 244)"/>
+<ellipse cx="704" cy="244" rx="5.4" ry="3.2" fill="#fff3d6" transform="rotate(19 704 244)"/>
+<path d="M702,260 Q716,262 730,274" fill="none" stroke="#ffd98f" stroke-width="2.6" stroke-opacity="0.34" stroke-linecap="round"/>
+<circle cx="730" cy="274" r="11.8" fill="#ffcf7a" opacity="0.43" filter="url(#glow)"/>
+<ellipse cx="730" cy="274" rx="7.7" ry="2.8" fill="#ffe9c4" opacity="0.15" transform="rotate(-12 730 274)"/>
+<ellipse cx="730" cy="274" rx="7.7" ry="2.8" fill="#ffe9c4" opacity="0.15" transform="rotate(64 730 274)"/>
+<ellipse cx="730" cy="274" rx="5.1" ry="3.1" fill="#fff3d6" transform="rotate(26 730 274)"/>
+<path d="M731,267 Q743,271 755,283" fill="none" stroke="#ffd98f" stroke-width="2.4" stroke-opacity="0.31" stroke-linecap="round"/>
+<circle cx="755" cy="283" r="11.0" fill="#ffcf7a" opacity="0.39" filter="url(#glow)"/>
+<ellipse cx="755" cy="283" rx="7.2" ry="2.6" fill="#ffe9c4" opacity="0.14" transform="rotate(-5 755 283)"/>
+<ellipse cx="755" cy="283" rx="7.2" ry="2.6" fill="#ffe9c4" opacity="0.14" transform="rotate(71 755 283)"/>
+<ellipse cx="755" cy="283" rx="4.8" ry="2.9" fill="#fff3d6" transform="rotate(33 755 283)"/>
+<path d="M769,288 Q779,292 790,304" fill="none" stroke="#ffd98f" stroke-width="2.2" stroke-opacity="0.28" stroke-linecap="round"/>
+<circle cx="790" cy="304" r="10.1" fill="#ffcf7a" opacity="0.34" filter="url(#glow)"/>
+<ellipse cx="790" cy="304" rx="6.6" ry="2.4" fill="#ffe9c4" opacity="0.12" transform="rotate(1 790 304)"/>
+<ellipse cx="790" cy="304" rx="6.6" ry="2.4" fill="#ffe9c4" opacity="0.12" transform="rotate(77 790 304)"/>
+<ellipse cx="790" cy="304" rx="4.4" ry="2.6" fill="#fff3d6" transform="rotate(39 790 304)"/>
+<path d="M800,313 Q809,318 817,330" fill="none" stroke="#ffd98f" stroke-width="2.0" stroke-opacity="0.24" stroke-linecap="round"/>
+<circle cx="817" cy="330" r="9.1" fill="#ffcf7a" opacity="0.30" filter="url(#glow)"/>
+<ellipse cx="817" cy="330" rx="6.0" ry="2.2" fill="#ffe9c4" opacity="0.11" transform="rotate(5 817 330)"/>
+<ellipse cx="817" cy="330" rx="6.0" ry="2.2" fill="#ffe9c4" opacity="0.11" transform="rotate(81 817 330)"/>
+<ellipse cx="817" cy="330" rx="4.0" ry="2.4" fill="#fff3d6" transform="rotate(43 817 330)"/>
+<g>
+<circle cx="614" cy="330" r="1.7" fill="#f4c983" opacity="0.20" filter="url(#glow)"/>
+<circle cx="131" cy="214" r="1.2" fill="#f4c983" opacity="0.43" filter="url(#glow)"/>
+<circle cx="838" cy="307" r="1.5" fill="#f4c983" opacity="0.38" filter="url(#glow)"/>
+<circle cx="271" cy="240" r="1.0" fill="#f4c983" opacity="0.47" filter="url(#glow)"/>
+<circle cx="181" cy="396" r="0.9" fill="#f4c983" opacity="0.39" filter="url(#glow)"/>
+<circle cx="470" cy="226" r="1.9" fill="#f4c983" opacity="0.16" filter="url(#glow)"/>
+<circle cx="183" cy="435" r="1.5" fill="#f4c983" opacity="0.18" filter="url(#glow)"/>
+<circle cx="1147" cy="448" r="0.9" fill="#f4c983" opacity="0.30" filter="url(#glow)"/>
+<circle cx="260" cy="188" r="1.6" fill="#f4c983" opacity="0.21" filter="url(#glow)"/>
+<circle cx="845" cy="81" r="1.0" fill="#f4c983" opacity="0.44" filter="url(#glow)"/>
+<circle cx="537" cy="232" r="1.6" fill="#f4c983" opacity="0.32" filter="url(#glow)"/>
+<circle cx="520" cy="73" r="1.7" fill="#f4c983" opacity="0.49" filter="url(#glow)"/>
+<circle cx="1135" cy="332" r="1.3" fill="#f4c983" opacity="0.28" filter="url(#glow)"/>
+<circle cx="838" cy="336" r="0.9" fill="#f4c983" opacity="0.23" filter="url(#glow)"/>
+</g>
+<rect width="1200" height="675" fill="url(#vig)"/>
+<rect width="1200" height="675" filter="url(#grain)" opacity="0.05"/>
+<text x="60" y="622" font-family="Mo" font-size="12" letter-spacing="3" fill="#e8b968" fill-opacity="0.55">FIELD NOTES</text>
+<text x="1140" y="622" text-anchor="end" font-family="Mo" font-size="12" letter-spacing="2" fill="#e8b968" fill-opacity="0.38">01 / 06</text>
+</svg>

--- a/beta/public/images/blog/nervensystem-n8n-automatisierung-light.svg
+++ b/beta/public/images/blog/nervensystem-n8n-automatisierung-light.svg
@@ -1,0 +1,115 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 675" width="1200" height="675" role="img" aria-label="Konzept (hell): eine Support-Mail fliesst durchs Nervensystem, wird am Pruef-Gate verifiziert und wird zum klassifizierten Ticket">
+<defs>
+<style>@font-face{font-family:'Mo';src:url(data:font/woff2;base64,d09GMgABAAAAAA7QAA8AAAAAHEwAAA53AAGzMwAAAAAAAAAAAAAAAAAAAAAAAAAAGigbIBwqBmA/U1RBVEgAgX4RCAqsLKJ4ATYCJAOCTguBKgAEIAVmByAb5RWjolZyVsaI/uKAJ0MfBYTACKR2WmgcqlNCrcK+9m3czlmg3OwcHiCxvo6QZPbncdv/GWET8qJtEERBQImSHOxSEy4D5oysF+n7WcHPCHmA7t3721fDDjigCbQtoDzwkMOAozGBw67/AcA5+31rZVXPhOpPB4AUsDtw9+LTsEznE561Gxt1gDZhjaQWB8+J0MAycHtU/O9aafMPyBVQIQrZs301proS/yazu8nm/l7miHgKQG6riFzVTAFIWJa1FfKUqxCyklRf5gzEKs6tRLzvreZMHlPkAjmAW1N4Du46AgGgyKk1jwChGpTK4D5GrWGMkYPXe9kCO5Ug5nNhDHkEAGAdmFjlMxWUeFcn3hdnxmBrLQA3QZrmkxSAd/QqCCC0mIfYkT5xVvASyK94+l74Tq/FLLxheEgIG/nf/d9CMOZjFN8MeDUvC5TJMbV9Hh6AjXdWVXaoD8xUE/+FsQk5KkEN+IxnJye9uSdiRRhSOCO4ilwNdTXBxgh8/TFrlBEoUEZFy8LKLSaJNWvJnc4urh6+fv4NG9fXAZRRqlUPa+5BY3SaU0pzLwCx4viQUqUOeQCcbOwYK62ceZuJByicVqLMx0aiKBElypSrUKmKnEI1FbVadTS0dPQMGhiZEIiIBAAAnsJV3v0gZ0uQ3wOAFQMcgOL1ivAhjlwQn/HSiTz8pMi5AEJMxSRQY3men2qBU0UMz7qKfQw4lnx6r0ogy88vKcwvKqyWFhULrmfPlRZJpaJ8gbR4S74uT5YnLcovqC7aIi6xLltziwTloi0iSRG3qN4qLdosXnps06qLBJtyRV9NgeBbz0JBhbaQL68Qt2MP/nIEuYLLlsmWZ9QE8shKLuO9ttiCZy/Fz1CY+dyIS0z7uftJACYXe9/Y/iedxprdSK/bUKx8ZeOtFAKsebAp5io0RXQV2J5VenvFaaPzm0zOCUOJu7Am0EPN6KkAoQTTowa89RHWJCGIR7rzTQwHZt748VxHozbUqbvVQRbmUjmn67cgK3mmMunc5v4tfnHrUKiD32TpDJ8HdRnpTLGoIACnTiHpiLvY5wJ+9NbB0chacSv6Lxehu16fy2+ZCD92Y3/olTmCVH7KSEFbvUV4F4nJwtURVqcj5xxlmMBMHpVBOoVkGomkpBI6wLdU4HbEmhqarA39ve9+0juOO9mPJooBQM+h9MK7k1g6QtKazfdEvK41/ZOHjJwR6uhi7jdUwZnDq3lnzEa+JmNzztm1jpGleR+Gh19qljughLpWO3nkE0VeMqfscHpK1zDYUssByGubUJhiTdUnn/TL62V+5hePkNMus4fMMLVm+U3ui2IL1MHVOl9JYHiI4soOpnVLBRKxXDU5xywqC+NHmqC8iUmKM9S9pZt1h7qXwgJHdDnswU3Q8hAimT+AvjmKagdZvZWidvQCZyj5LGQpqe+LtAT/QOWDnTsvwf9zuHzm9f0eCX+WgTHlWgXswYnnFhreUDOYetavvyVd/ndO0Vd48OiEWcj+Sm+hmP25PRp90SADQaHPzzdHf2gVGBiyqjHSVzBJR+l1pQDVWFPU1obCB4Yzj0mdeYh1nqQSrTbJ+jRnXkKFOHZTqrVZWgRcb72sciG+biu29/Ieg3tdfM0ISQqtJf7f/v6w/d+W/YwjGvOf9GEt/aNJ6jeHMuZv3t7uePVMwz2yjiOuI14iqaSDUAotbndJ0pqixMHF/R8xEP2BzpG4cuUNzcW42HRfEiZz7dXwIiKf4I/8dfsQd45FzvZpTG3B6UMxMHH5PH7iL7Qasj3U2swLBlkvLmTsQ9zzrIkqdlFxXDnPY2iaGNRSJoRMhzFK5U/enLOSo5Mf3nvmyeFun1c10qd2JcTwxwNs9snZuX62VuUPVetznGmVJtTA7RmcPCZxXCRoM1pCTeg4PIe8lkaj14LmoE6SnM3YL5+atl8+yybbDixtGm0RSsPxiNkS9lTv5Vqq94Q9FmcyKcasQDZz6CCw2au4tTi6YGoKnb/WzDUnIgNTh48cmVobiACbvQmzn0Xj0S+6MPRk74ofs7CNjtN6UElCM3HvZUvTzstn2YS7x+LtE3syQqk7mmgyRTzKvVyLak/UYzEEG1RtO6+J/91P86+cf7k+Fq4Fe5bJ3HzczRkmy7TK/q1A45tLbsZ3Lb4BkEnIfpt1jECJXF6SSiCEcPJN5s251SNw5KMZw/jQV49nmWzDH/33yy+HnixzwbXHYxDGDsnz5pjs/mMDSnzg/iwzl3dIDmR2qWDt4+OYresnx4NagmeS9svnFghZY5y0MHePRMIUdlXvaW2t3ht2m3zpRh/IPTk3YLNvolGDrcPnI5TPhPZvHFjAMZ/LHfPiBVie20czy+Fd3sf3WlS/qoObB8k5I38xE/smuvV14YA6biP5pE3oLX6GkT5UtubRnFYytR9FPA5nxI32g1ESmnb4R4SBjLBHQyG5Xu/dWlZZ8SGuiW+mNrJ6ZbDRbmYH9RTVb7X35royQlbuccvrPRGnofxpqswjY7b02WqbbWYHM6oFYuotnIffmgK1ZGLP8UvPM8+noy2hEKm0K5cyPeDX0ePc/cdvfSTnuMFI5HHWfWpBxMuBLADJhiX7Ke1W7An6R3se7Og5ZadapuvBzke7e84oWwZ4FW9d2nVxyLPrjUsrQM8cu2MJv31+B6dh+KxQH6usc6l9NGKkN1f67G6L6cX70zliNMGxHYNTve/K/pNWIPqkoorPJnKknWSsRE4ZA1WVnlrNxaWZs8rlSggX1vh3bHz0ecF8OIsVB9d+8JfWkL1e43IyaZB/kijmDQ+2cOEBt86vqUo57VVpnxYshWjUa1vB2LY86kO2lhpb8zUp4W2k2UDFBzguPkAZkO3elPAaB9OqhYJCjv/wpNpX+sPaQQXOhgXzz99a5d9RFav3aavSdmdVyq/RucMDXEt4EHSFoRGvdQVj6/KQj/IPumzLmW37BZhO+hs89U9kcjaSM+z3PoUwHAnYHFEErzYEgih0DbqmNKe84aMn0CMIlBdbWuQO//Up4W1PO4Jhi5VRJXQN3gG3dToUtkz1uT3mtGEHpr93mtL9GiTyNbdBc05V1FejIcNt8Xi0DXqyWHXyuX/4t6ssUb2StSWxI2KkzK5wBNmBRq9dufYrKn3yTnQnhtHT0VXVnfXfrG1CLhkVCNPAZvFLxM6JFz98u77v+j/6R48B6a7tZYayVbSPQojaqNyFPkSglEV4sycfY/VptHqv0F1wvDNQ77Kk+jowDrxZtulvVV0cY98z5XsbcPcHHz7rgjC1S+WgG1WsOYkdyBK2q9wVCo/OAepCauTZsCRyiMLTlpPYttIyGKPoAY4joibPArHTr4oS87c7uCZHrCeiXaUoQLhXTEXuIPbdn3f6W/5of2srjJZf41FXpdzuypRXDbmn47z79xHkDlUTNyfXVHc7MR/96jltL1TigUwa+m8FsOjWIy+s3YpezD1+Ntfn9VhGwyPV0XtqS+ZfRNBY6O/WmmldSjhBmppsrvKqLa23nR0WMUqHWlMXyKjcnrTGEF5NCVsKglXW1YodF57yR3NRRmmr1Ro9bZVA/+5t7OxocHeN9sZ9SYYUwC2sTp8wth0YXnDRrhh2uGqGwiXW2lit09/UqL3HaQ8E3b/DUiQUQP/if+WyyhPQa0+g1xHkFMZah9qS2BkxBi3OAB2wYxl9ICtxZUj443sxd/69t+QwB1YH/Brf3ZHx+INvC66/eMgfWZ4FjI9I7iK6jnniyBM9d/If0l2nvCbeF46cjhw7L+oq3/VYLnfR3Wfczb2Ov76zEeI4Nk2iS5aeaQTzvVv+i/HNst2TkYmM7fKp6RYTbCQ6zrKZngK38UwkoSf9ir2pjEDI1esCfkImhfD/BnaK70Edis9iSjJrxB9i0Ic0C3Ojg6b8e2+ukv/+gzbERAoCGWFh/5HlaarfYOQcxsoo9lKKnxh/rWv7MRjkkunlMUEqLRS6sMmlDm39sl57XnCnxozN8tdcSpPf7PH6GscywvzYfFe/v1djTNo8cZoWy5j83v6oz90+rYOD53DR5Hvcmwxmzsl8J+gAlcTfp7NnUEa4HLU7/HEc0lcGPQptTVgp5DQnLGF1qXD9f9Onpb4+p3k0EHCMjTigTkJPBK3H96Z3nu2aGfLEmlIqY+ilTO7dF9tsCY/mENGz4dIRuspA9tssI1TUOTFmDyTIZDqG6KS3PqRQB3Q6RShQAw+N2d+efC7K7scfRj2hjtMdZ+26hAW1hJzUulv9kZaeUPGGh1DYYzalOvRNTZ16Y8rsocIvbggXsz0Rv7t1QksmyIzL64whOkYjpzfj8nMWn9li8NhsVq/NAHmgek3fFR/Xtxo3W23YUzdm3E6umqIpmnnO75dWluCHixsvNi4tTNiuheHRDXyOpmeF+X9iAzHY8G+0PgrdoxEfPqHsJIoSKH2yByITJ5afEAxij8QJKAC/zGOLnj8n4kRE4vqt4aqernQXQ2mwPuXvP4AYkwtxdVuUXJp8C5SwnNCPJK3ESYldMTVR7dHapDjEmKL+0pQgRmUQ+9l7wS+nwbWPcO3dC1sBYDsAz8lfBsX6jzy9ADvs9Dau/8pT8J4gGoBXL6aPrQ/xXcqahxLJQiLxZ8n3AMSu/gX4RY869bLErYaidWdtu8T+Wx6f/yUBwGfpa1Jws1+l//9l/H+Od4KgAsK891bWuzHDS1cT/rtPkBynmgTxKz1mwvYrsKCIZaknDXagSYmhB/RElm+voAK5XW1dAVRyBT0pgYwALJH51IQDKoiexo4RWwZKwGQFokUSix1pYgE2ghEaKJ5HdhbWm7upfAD4nn6c8CuM0ILI0EUwWjHg6gQQAHDypxqDihBOmp/OEzCiAXk+8IgBXowAKCIGeex2rXiLes+4Xv1mjeg0JWVXg9ZrwAzKjE4jonW3uHGjEB57Tzp5fY1OBoQT) format('woff2');}</style>
+<radialGradient id="ground" cx="46%" cy="48%" r="80%">
+  <stop offset="0%" stop-color="#fdfaf3"/><stop offset="58%" stop-color="#f3ecdb"/><stop offset="100%" stop-color="#e4d9c1"/>
+</radialGradient>
+<radialGradient id="coreglow" cx="50%" cy="50%" r="50%">
+  <stop offset="0%" stop-color="#ffdd93" stop-opacity="0.55"/><stop offset="55%" stop-color="#f2c46a" stop-opacity="0.16"/><stop offset="100%" stop-color="#f0ab4c" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="heart" cx="50%" cy="50%" r="50%">
+  <stop offset="0%" stop-color="#ffe3a0" stop-opacity="0.55"/><stop offset="60%" stop-color="#f0ab4c" stop-opacity="0.12"/><stop offset="100%" stop-color="#f0ab4c" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="halo" cx="50%" cy="50%" r="50%">
+  <stop offset="0%" stop-color="#f6bf5c" stop-opacity="0.7"/><stop offset="100%" stop-color="#f6bf5c" stop-opacity="0"/>
+</radialGradient>
+<linearGradient id="cell" x1="0" y1="0" x2="0" y2="1">
+  <stop offset="0%" stop-color="#f0b957"/><stop offset="55%" stop-color="#d5923c"/><stop offset="100%" stop-color="#b0742c"/>
+</linearGradient>
+<linearGradient id="hot" x1="0" y1="0" x2="0" y2="1">
+  <stop offset="0%" stop-color="#ffe6a6"/><stop offset="50%" stop-color="#f6c065"/><stop offset="100%" stop-color="#dc9d3e"/>
+</linearGradient>
+<linearGradient id="screen" x1="0" y1="0" x2="0" y2="1">
+  <stop offset="0%" stop-color="#ffe7ad"/><stop offset="100%" stop-color="#e6ab52"/>
+</linearGradient>
+<linearGradient id="panel" x1="0" y1="0" x2="0" y2="1">
+  <stop offset="0%" stop-color="#fffaf0"/><stop offset="100%" stop-color="#f4e8d0"/>
+</linearGradient>
+<radialGradient id="vig" cx="50%" cy="46%" r="66%">
+  <stop offset="62%" stop-color="#8a6a34" stop-opacity="0"/><stop offset="100%" stop-color="#8a6a34" stop-opacity="0.16"/>
+</radialGradient>
+<filter id="glow" x="-120%" y="-120%" width="340%" height="340%"><feGaussianBlur stdDeviation="6"/></filter>
+<filter id="glowbig" x="-150%" y="-150%" width="400%" height="400%"><feGaussianBlur stdDeviation="11"/></filter>
+<filter id="softbig" x="-60%" y="-60%" width="220%" height="220%"><feGaussianBlur stdDeviation="24"/></filter>
+<filter id="lift" x="-40%" y="-40%" width="180%" height="200%"><feDropShadow dx="0" dy="6" stdDeviation="11" flood-color="#6e4e24" flood-opacity="0.26"/></filter>
+<filter id="grain"><feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="2" stitchTiles="stitch"/>
+  <feColorMatrix type="matrix" values="0 0 0 0 0.42  0 0 0 0 0.30  0 0 0 0 0.12  0 0 0 0.5 0"/></filter>
+</defs>
+<rect width="1200" height="675" fill="url(#ground)"/>
+<ellipse cx="620" cy="326" rx="520" ry="250" fill="url(#coreglow)" filter="url(#softbig)"/>
+<g>
+<path d="M176,326 Q222,326 268,326" fill="none" stroke="#b07a34" stroke-width="2.2" stroke-opacity="0.55" stroke-linecap="round"/>
+<path d="M268,326 Q320,326 372,250" fill="none" stroke="#b07a34" stroke-width="2.2" stroke-opacity="0.55" stroke-linecap="round"/>
+<path d="M268,326 Q326,326 384,326" fill="none" stroke="#b07a34" stroke-width="2.2" stroke-opacity="0.55" stroke-linecap="round"/>
+<path d="M268,326 Q320,326 372,404" fill="none" stroke="#b07a34" stroke-width="2.2" stroke-opacity="0.55" stroke-linecap="round"/>
+<path d="M372,250 Q439,250 506,326" fill="none" stroke="#b07a34" stroke-width="2.2" stroke-opacity="0.55" stroke-linecap="round"/>
+<path d="M384,326 Q445,326 506,326" fill="none" stroke="#b07a34" stroke-width="2.2" stroke-opacity="0.55" stroke-linecap="round"/>
+<path d="M372,404 Q439,404 506,326" fill="none" stroke="#b07a34" stroke-width="2.2" stroke-opacity="0.55" stroke-linecap="round"/>
+<path d="M506,326 Q525,326 544,326" fill="none" stroke="#b07a34" stroke-width="2.2" stroke-opacity="0.55" stroke-linecap="round"/>
+<path d="M592,326 Q632,326 672,326" fill="none" stroke="#b07a34" stroke-width="2.2" stroke-opacity="0.55" stroke-linecap="round"/>
+<path d="M672,326 Q722,326 772,326" fill="none" stroke="#b07a34" stroke-width="2.2" stroke-opacity="0.55" stroke-linecap="round"/>
+<path d="M772,326 Q815,326 858,326" fill="none" stroke="#b07a34" stroke-width="2.2" stroke-opacity="0.55" stroke-linecap="round"/>
+</g>
+<circle cx="268" cy="326" r="5" fill="#fdf7ea" stroke="#9a6a28" stroke-opacity="0.8" stroke-width="1.5"/>
+<circle cx="372" cy="250" r="5" fill="#fdf7ea" stroke="#9a6a28" stroke-opacity="0.8" stroke-width="1.5"/>
+<circle cx="384" cy="326" r="5" fill="#fdf7ea" stroke="#9a6a28" stroke-opacity="0.8" stroke-width="1.5"/>
+<circle cx="372" cy="404" r="5" fill="#fdf7ea" stroke="#9a6a28" stroke-opacity="0.8" stroke-width="1.5"/>
+<circle cx="506" cy="326" r="5" fill="#fdf7ea" stroke="#9a6a28" stroke-opacity="0.8" stroke-width="1.5"/>
+<circle cx="672" cy="326" r="5" fill="#fdf7ea" stroke="#9a6a28" stroke-opacity="0.8" stroke-width="1.5"/>
+<circle cx="772" cy="326" r="5" fill="#fdf7ea" stroke="#9a6a28" stroke-opacity="0.8" stroke-width="1.5"/>
+<circle cx="227" cy="326" r="5.7" fill="url(#halo)" filter="url(#glow)"/>
+<circle cx="227" cy="326" r="2.2" fill="#d59433" stroke="#8a5a20" stroke-opacity="0.4" stroke-width="0.6"/>
+<circle cx="225.9" cy="325.3" r="0.9" fill="#fff3d6"/>
+<circle cx="330" cy="308" r="5.7" fill="url(#halo)" filter="url(#glow)"/>
+<circle cx="330" cy="308" r="2.2" fill="#d59433" stroke="#8a5a20" stroke-opacity="0.4" stroke-width="0.6"/>
+<circle cx="329.4" cy="307.2" r="0.9" fill="#fff3d6"/>
+<circle cx="734" cy="326" r="5.7" fill="url(#halo)" filter="url(#glow)"/>
+<circle cx="734" cy="326" r="2.2" fill="#d59433" stroke="#8a5a20" stroke-opacity="0.4" stroke-width="0.6"/>
+<circle cx="733.1" cy="325.3" r="0.9" fill="#fff3d6"/>
+<circle cx="467" cy="326" r="5.7" fill="url(#halo)" filter="url(#glow)"/>
+<circle cx="467" cy="326" r="2.2" fill="#d59433" stroke="#8a5a20" stroke-opacity="0.4" stroke-width="0.6"/>
+<circle cx="465.9" cy="325.3" r="0.9" fill="#fff3d6"/>
+<circle cx="452" cy="385" r="5.7" fill="url(#halo)" filter="url(#glow)"/>
+<circle cx="452" cy="385" r="2.2" fill="#d59433" stroke="#8a5a20" stroke-opacity="0.4" stroke-width="0.6"/>
+<circle cx="451.2" cy="384.7" r="0.9" fill="#fff3d6"/>
+<circle cx="646" cy="326" r="5.7" fill="url(#halo)" filter="url(#glow)"/>
+<circle cx="646" cy="326" r="2.2" fill="#d59433" stroke="#8a5a20" stroke-opacity="0.4" stroke-width="0.6"/>
+<circle cx="644.9" cy="325.3" r="0.9" fill="#fff3d6"/>
+<g filter="url(#lift)"><rect x="96" y="292" width="86" height="64" rx="7" fill="url(#panel)" stroke="#9a6a28" stroke-opacity="0.6" stroke-width="1.4"/></g>
+<path d="M98,296 L139.0,324.0 L180,296" fill="none" stroke="#9a6a28" stroke-opacity="0.65" stroke-width="1.5"/>
+<rect x="548" y="230" width="40" height="192" rx="10" fill="url(#screen)" opacity="0.35"/>
+<rect x="548" y="230" width="40" height="192" rx="10" fill="none" stroke="#9a6a28" stroke-opacity="0.6" stroke-width="1.5"/>
+<path d="M568,296 l16,7 v14 q0,15 -16,23 q-16,-8 -16,-23 v-14 z" fill="none" stroke="#b07d33" stroke-opacity="0.9" stroke-width="1.7"/>
+<path d="M561,324 l5,6 l10,-12" fill="none" stroke="#b07d33" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+<rect x="554" y="360" width="7" height="9" rx="1.5" fill="#3a2a16"/>
+<rect x="564" y="360" width="7" height="9" rx="1.5" fill="#3a2a16"/>
+<rect x="574" y="360" width="7" height="9" rx="1.5" fill="#3a2a16"/>
+<circle cx="544" cy="326" r="6.2" fill="url(#halo)" filter="url(#glow)"/>
+<circle cx="544" cy="326" r="2.4" fill="#d59433" stroke="#8a5a20" stroke-opacity="0.4" stroke-width="0.6"/>
+<circle cx="543.3" cy="325.3" r="1.0" fill="#fff3d6"/>
+<ellipse cx="960" cy="326" rx="150" ry="120" fill="url(#heart)" filter="url(#softbig)"/>
+<g filter="url(#lift)"><rect x="862" y="262" width="196" height="128" rx="12" fill="url(#panel)" stroke="#9a6a28" stroke-opacity="0.6" stroke-width="1.4"/></g>
+<rect x="882" y="284" width="86" height="22" rx="11" fill="url(#screen)"/>
+<circle cx="895" cy="295" r="4" fill="#3a2a16"/>
+<rect x="882" y="322" width="140" height="7" rx="3.5" fill="#b5822f" opacity="0.60"/>
+<rect x="882" y="342" width="112" height="7" rx="3.5" fill="#b5822f" opacity="0.52"/>
+<rect x="882" y="362" width="84" height="7" rx="3.5" fill="#b5822f" opacity="0.44"/>
+<g>
+<circle cx="486" cy="236" r="1.5" fill="#d59a44" opacity="0.30"/>
+<circle cx="653" cy="221" r="1.0" fill="#d59a44" opacity="0.33"/>
+<circle cx="145" cy="102" r="1.3" fill="#d59a44" opacity="0.49"/>
+<circle cx="621" cy="284" r="1.9" fill="#d59a44" opacity="0.47"/>
+<circle cx="710" cy="154" r="1.5" fill="#d59a44" opacity="0.31"/>
+<circle cx="1116" cy="74" r="1.4" fill="#d59a44" opacity="0.41"/>
+<circle cx="745" cy="289" r="1.8" fill="#d59a44" opacity="0.27"/>
+<circle cx="994" cy="435" r="1.0" fill="#d59a44" opacity="0.30"/>
+<circle cx="497" cy="217" r="1.5" fill="#d59a44" opacity="0.28"/>
+<circle cx="795" cy="421" r="1.9" fill="#d59a44" opacity="0.45"/>
+<circle cx="347" cy="365" r="1.8" fill="#d59a44" opacity="0.38"/>
+<circle cx="822" cy="177" r="1.8" fill="#d59a44" opacity="0.27"/>
+</g>
+<rect width="1200" height="675" fill="url(#vig)"/>
+<rect width="1200" height="675" filter="url(#grain)" opacity="0.04"/>
+<text x="60" y="622" font-family="Mo" font-size="12" letter-spacing="3" fill="#9a6a2c" fill-opacity="0.8">FIELD NOTES</text>
+<text x="1140" y="622" text-anchor="end" font-family="Mo" font-size="12" letter-spacing="2" fill="#9a6a2c" fill-opacity="0.55">03 / 06</text>
+</svg>

--- a/beta/public/images/blog/nervensystem-n8n-automatisierung.svg
+++ b/beta/public/images/blog/nervensystem-n8n-automatisierung.svg
@@ -1,0 +1,116 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 675" width="1200" height="675" role="img" aria-label="Konzept: eine Support-Mail fliesst durch das Nervensystem, wird an einem Pruef- und Schwaerzungs-Gate verifiziert und kommt als klassifiziertes Ticket heraus">
+<defs>
+<style>@font-face{font-family:'Mo';src:url(data:font/woff2;base64,d09GMgABAAAAAA7QAA8AAAAAHEwAAA53AAGzMwAAAAAAAAAAAAAAAAAAAAAAAAAAGigbIBwqBmA/U1RBVEgAgX4RCAqsLKJ4ATYCJAOCTguBKgAEIAVmByAb5RWjolZyVsaI/uKAJ0MfBYTACKR2WmgcqlNCrcK+9m3czlmg3OwcHiCxvo6QZPbncdv/GWET8qJtEERBQImSHOxSEy4D5oysF+n7WcHPCHmA7t3721fDDjigCbQtoDzwkMOAozGBw67/AcA5+31rZVXPhOpPB4AUsDtw9+LTsEznE561Gxt1gDZhjaQWB8+J0MAycHtU/O9aafMPyBVQIQrZs301proS/yazu8nm/l7miHgKQG6riFzVTAFIWJa1FfKUqxCyklRf5gzEKs6tRLzvreZMHlPkAjmAW1N4Du46AgGgyKk1jwChGpTK4D5GrWGMkYPXe9kCO5Ug5nNhDHkEAGAdmFjlMxWUeFcn3hdnxmBrLQA3QZrmkxSAd/QqCCC0mIfYkT5xVvASyK94+l74Tq/FLLxheEgIG/nf/d9CMOZjFN8MeDUvC5TJMbV9Hh6AjXdWVXaoD8xUE/+FsQk5KkEN+IxnJye9uSdiRRhSOCO4ilwNdTXBxgh8/TFrlBEoUEZFy8LKLSaJNWvJnc4urh6+fv4NG9fXAZRRqlUPa+5BY3SaU0pzLwCx4viQUqUOeQCcbOwYK62ceZuJByicVqLMx0aiKBElypSrUKmKnEI1FbVadTS0dPQMGhiZEIiIBAAAnsJV3v0gZ0uQ3wOAFQMcgOL1ivAhjlwQn/HSiTz8pMi5AEJMxSRQY3men2qBU0UMz7qKfQw4lnx6r0ogy88vKcwvKqyWFhULrmfPlRZJpaJ8gbR4S74uT5YnLcovqC7aIi6xLltziwTloi0iSRG3qN4qLdosXnps06qLBJtyRV9NgeBbz0JBhbaQL68Qt2MP/nIEuYLLlsmWZ9QE8shKLuO9ttiCZy/Fz1CY+dyIS0z7uftJACYXe9/Y/iedxprdSK/bUKx8ZeOtFAKsebAp5io0RXQV2J5VenvFaaPzm0zOCUOJu7Am0EPN6KkAoQTTowa89RHWJCGIR7rzTQwHZt748VxHozbUqbvVQRbmUjmn67cgK3mmMunc5v4tfnHrUKiD32TpDJ8HdRnpTLGoIACnTiHpiLvY5wJ+9NbB0chacSv6Lxehu16fy2+ZCD92Y3/olTmCVH7KSEFbvUV4F4nJwtURVqcj5xxlmMBMHpVBOoVkGomkpBI6wLdU4HbEmhqarA39ve9+0juOO9mPJooBQM+h9MK7k1g6QtKazfdEvK41/ZOHjJwR6uhi7jdUwZnDq3lnzEa+JmNzztm1jpGleR+Gh19qljughLpWO3nkE0VeMqfscHpK1zDYUssByGubUJhiTdUnn/TL62V+5hePkNMus4fMMLVm+U3ui2IL1MHVOl9JYHiI4soOpnVLBRKxXDU5xywqC+NHmqC8iUmKM9S9pZt1h7qXwgJHdDnswU3Q8hAimT+AvjmKagdZvZWidvQCZyj5LGQpqe+LtAT/QOWDnTsvwf9zuHzm9f0eCX+WgTHlWgXswYnnFhreUDOYetavvyVd/ndO0Vd48OiEWcj+Sm+hmP25PRp90SADQaHPzzdHf2gVGBiyqjHSVzBJR+l1pQDVWFPU1obCB4Yzj0mdeYh1nqQSrTbJ+jRnXkKFOHZTqrVZWgRcb72sciG+biu29/Ieg3tdfM0ISQqtJf7f/v6w/d+W/YwjGvOf9GEt/aNJ6jeHMuZv3t7uePVMwz2yjiOuI14iqaSDUAotbndJ0pqixMHF/R8xEP2BzpG4cuUNzcW42HRfEiZz7dXwIiKf4I/8dfsQd45FzvZpTG3B6UMxMHH5PH7iL7Qasj3U2swLBlkvLmTsQ9zzrIkqdlFxXDnPY2iaGNRSJoRMhzFK5U/enLOSo5Mf3nvmyeFun1c10qd2JcTwxwNs9snZuX62VuUPVetznGmVJtTA7RmcPCZxXCRoM1pCTeg4PIe8lkaj14LmoE6SnM3YL5+atl8+yybbDixtGm0RSsPxiNkS9lTv5Vqq94Q9FmcyKcasQDZz6CCw2au4tTi6YGoKnb/WzDUnIgNTh48cmVobiACbvQmzn0Xj0S+6MPRk74ofs7CNjtN6UElCM3HvZUvTzstn2YS7x+LtE3syQqk7mmgyRTzKvVyLak/UYzEEG1RtO6+J/91P86+cf7k+Fq4Fe5bJ3HzczRkmy7TK/q1A45tLbsZ3Lb4BkEnIfpt1jECJXF6SSiCEcPJN5s251SNw5KMZw/jQV49nmWzDH/33yy+HnixzwbXHYxDGDsnz5pjs/mMDSnzg/iwzl3dIDmR2qWDt4+OYresnx4NagmeS9svnFghZY5y0MHePRMIUdlXvaW2t3ht2m3zpRh/IPTk3YLNvolGDrcPnI5TPhPZvHFjAMZ/LHfPiBVie20czy+Fd3sf3WlS/qoObB8k5I38xE/smuvV14YA6biP5pE3oLX6GkT5UtubRnFYytR9FPA5nxI32g1ESmnb4R4SBjLBHQyG5Xu/dWlZZ8SGuiW+mNrJ6ZbDRbmYH9RTVb7X35royQlbuccvrPRGnofxpqswjY7b02WqbbWYHM6oFYuotnIffmgK1ZGLP8UvPM8+noy2hEKm0K5cyPeDX0ePc/cdvfSTnuMFI5HHWfWpBxMuBLADJhiX7Ke1W7An6R3se7Og5ZadapuvBzke7e84oWwZ4FW9d2nVxyLPrjUsrQM8cu2MJv31+B6dh+KxQH6usc6l9NGKkN1f67G6L6cX70zliNMGxHYNTve/K/pNWIPqkoorPJnKknWSsRE4ZA1WVnlrNxaWZs8rlSggX1vh3bHz0ecF8OIsVB9d+8JfWkL1e43IyaZB/kijmDQ+2cOEBt86vqUo57VVpnxYshWjUa1vB2LY86kO2lhpb8zUp4W2k2UDFBzguPkAZkO3elPAaB9OqhYJCjv/wpNpX+sPaQQXOhgXzz99a5d9RFav3aavSdmdVyq/RucMDXEt4EHSFoRGvdQVj6/KQj/IPumzLmW37BZhO+hs89U9kcjaSM+z3PoUwHAnYHFEErzYEgih0DbqmNKe84aMn0CMIlBdbWuQO//Up4W1PO4Jhi5VRJXQN3gG3dToUtkz1uT3mtGEHpr93mtL9GiTyNbdBc05V1FejIcNt8Xi0DXqyWHXyuX/4t6ssUb2StSWxI2KkzK5wBNmBRq9dufYrKn3yTnQnhtHT0VXVnfXfrG1CLhkVCNPAZvFLxM6JFz98u77v+j/6R48B6a7tZYayVbSPQojaqNyFPkSglEV4sycfY/VptHqv0F1wvDNQ77Kk+jowDrxZtulvVV0cY98z5XsbcPcHHz7rgjC1S+WgG1WsOYkdyBK2q9wVCo/OAepCauTZsCRyiMLTlpPYttIyGKPoAY4joibPArHTr4oS87c7uCZHrCeiXaUoQLhXTEXuIPbdn3f6W/5of2srjJZf41FXpdzuypRXDbmn47z79xHkDlUTNyfXVHc7MR/96jltL1TigUwa+m8FsOjWIy+s3YpezD1+Ntfn9VhGwyPV0XtqS+ZfRNBY6O/WmmldSjhBmppsrvKqLa23nR0WMUqHWlMXyKjcnrTGEF5NCVsKglXW1YodF57yR3NRRmmr1Ro9bZVA/+5t7OxocHeN9sZ9SYYUwC2sTp8wth0YXnDRrhh2uGqGwiXW2lit09/UqL3HaQ8E3b/DUiQUQP/if+WyyhPQa0+g1xHkFMZah9qS2BkxBi3OAB2wYxl9ICtxZUj443sxd/69t+QwB1YH/Brf3ZHx+INvC66/eMgfWZ4FjI9I7iK6jnniyBM9d/If0l2nvCbeF46cjhw7L+oq3/VYLnfR3Wfczb2Ov76zEeI4Nk2iS5aeaQTzvVv+i/HNst2TkYmM7fKp6RYTbCQ6zrKZngK38UwkoSf9ir2pjEDI1esCfkImhfD/BnaK70Edis9iSjJrxB9i0Ic0C3Ojg6b8e2+ukv/+gzbERAoCGWFh/5HlaarfYOQcxsoo9lKKnxh/rWv7MRjkkunlMUEqLRS6sMmlDm39sl57XnCnxozN8tdcSpPf7PH6GscywvzYfFe/v1djTNo8cZoWy5j83v6oz90+rYOD53DR5Hvcmwxmzsl8J+gAlcTfp7NnUEa4HLU7/HEc0lcGPQptTVgp5DQnLGF1qXD9f9Onpb4+p3k0EHCMjTigTkJPBK3H96Z3nu2aGfLEmlIqY+ilTO7dF9tsCY/mENGz4dIRuspA9tssI1TUOTFmDyTIZDqG6KS3PqRQB3Q6RShQAw+N2d+efC7K7scfRj2hjtMdZ+26hAW1hJzUulv9kZaeUPGGh1DYYzalOvRNTZ16Y8rsocIvbggXsz0Rv7t1QksmyIzL64whOkYjpzfj8nMWn9li8NhsVq/NAHmgek3fFR/Xtxo3W23YUzdm3E6umqIpmnnO75dWluCHixsvNi4tTNiuheHRDXyOpmeF+X9iAzHY8G+0PgrdoxEfPqHsJIoSKH2yByITJ5afEAxij8QJKAC/zGOLnj8n4kRE4vqt4aqernQXQ2mwPuXvP4AYkwtxdVuUXJp8C5SwnNCPJK3ESYldMTVR7dHapDjEmKL+0pQgRmUQ+9l7wS+nwbWPcO3dC1sBYDsAz8lfBsX6jzy9ADvs9Dau/8pT8J4gGoBXL6aPrQ/xXcqahxLJQiLxZ8n3AMSu/gX4RY869bLErYaidWdtu8T+Wx6f/yUBwGfpa1Jws1+l//9l/H+Od4KgAsK891bWuzHDS1cT/rtPkBynmgTxKz1mwvYrsKCIZaknDXagSYmhB/RElm+voAK5XW1dAVRyBT0pgYwALJH51IQDKoiexo4RWwZKwGQFokUSix1pYgE2ghEaKJ5HdhbWm7upfAD4nn6c8CuM0ILI0EUwWjHg6gQQAHDypxqDihBOmp/OEzCiAXk+8IgBXowAKCIGeex2rXiLes+4Xv1mjeg0JWVXg9ZrwAzKjE4jonW3uHGjEB57Tzp5fY1OBoQT) format('woff2');}</style>
+<radialGradient id="ground" cx="50%" cy="50%" r="80%">
+  <stop offset="0%" stop-color="#1c1610"/><stop offset="55%" stop-color="#120e0a"/>
+  <stop offset="100%" stop-color="#090705"/>
+</radialGradient>
+<radialGradient id="coreglow" cx="50%" cy="50%" r="50%">
+  <stop offset="0%" stop-color="#f5bd62" stop-opacity="0.52"/>
+  <stop offset="45%" stop-color="#c8863c" stop-opacity="0.20"/>
+  <stop offset="100%" stop-color="#c8863c" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="heart" cx="50%" cy="50%" r="50%">
+  <stop offset="0%" stop-color="#ffdf99" stop-opacity="0.55"/>
+  <stop offset="60%" stop-color="#f0ab4c" stop-opacity="0.12"/>
+  <stop offset="100%" stop-color="#f0ab4c" stop-opacity="0"/>
+</radialGradient>
+<linearGradient id="cell" x1="0" y1="0" x2="0" y2="1">
+  <stop offset="0%" stop-color="#eab866"/><stop offset="52%" stop-color="#b07e40"/>
+  <stop offset="100%" stop-color="#5f4223"/>
+</linearGradient>
+<radialGradient id="hot" cx="50%" cy="42%" r="60%">
+  <stop offset="0%" stop-color="#ffe0a0"/><stop offset="55%" stop-color="#e2a24a"/>
+  <stop offset="100%" stop-color="#7a5327"/>
+</radialGradient>
+<radialGradient id="screen" cx="50%" cy="38%" r="75%">
+  <stop offset="0%" stop-color="#ffdf9c"/><stop offset="60%" stop-color="#e0a24c"/>
+  <stop offset="100%" stop-color="#9c6e34"/>
+</radialGradient>
+<linearGradient id="panel" x1="0" y1="0" x2="0" y2="1">
+  <stop offset="0%" stop-color="#2a2015" stop-opacity="0.92"/>
+  <stop offset="100%" stop-color="#140f0a" stop-opacity="0.92"/>
+</linearGradient>
+<radialGradient id="vig" cx="50%" cy="48%" r="62%">
+  <stop offset="60%" stop-color="#000" stop-opacity="0"/>
+  <stop offset="100%" stop-color="#050403" stop-opacity="0.74"/>
+</radialGradient>
+<filter id="glow" x="-120%" y="-120%" width="340%" height="340%"><feGaussianBlur stdDeviation="7"/></filter>
+<filter id="glowbig" x="-150%" y="-150%" width="400%" height="400%"><feGaussianBlur stdDeviation="13"/></filter>
+<filter id="softbig" x="-60%" y="-60%" width="220%" height="220%"><feGaussianBlur stdDeviation="26"/></filter>
+<filter id="grain"><feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="2" stitchTiles="stitch"/>
+  <feColorMatrix type="matrix" values="0 0 0 0 0.9  0 0 0 0 0.7  0 0 0 0 0.4  0 0 0 0.5 0"/></filter>
+</defs>
+<rect width="1200" height="675" fill="url(#ground)"/>
+<ellipse cx="620" cy="326" rx="520" ry="250" fill="url(#coreglow)" filter="url(#softbig)"/>
+<g>
+<path d="M176,326 Q222,326 268,326" fill="none" stroke="#d89b4d" stroke-width="2.2" stroke-opacity="0.5" stroke-linecap="round"/>
+<path d="M268,326 Q320,326 372,250" fill="none" stroke="#d89b4d" stroke-width="2.2" stroke-opacity="0.5" stroke-linecap="round"/>
+<path d="M268,326 Q326,326 384,326" fill="none" stroke="#d89b4d" stroke-width="2.2" stroke-opacity="0.5" stroke-linecap="round"/>
+<path d="M268,326 Q320,326 372,404" fill="none" stroke="#d89b4d" stroke-width="2.2" stroke-opacity="0.5" stroke-linecap="round"/>
+<path d="M372,250 Q439,250 506,326" fill="none" stroke="#d89b4d" stroke-width="2.2" stroke-opacity="0.5" stroke-linecap="round"/>
+<path d="M384,326 Q445,326 506,326" fill="none" stroke="#d89b4d" stroke-width="2.2" stroke-opacity="0.5" stroke-linecap="round"/>
+<path d="M372,404 Q439,404 506,326" fill="none" stroke="#d89b4d" stroke-width="2.2" stroke-opacity="0.5" stroke-linecap="round"/>
+<path d="M506,326 Q525,326 544,326" fill="none" stroke="#d89b4d" stroke-width="2.2" stroke-opacity="0.5" stroke-linecap="round"/>
+<path d="M592,326 Q632,326 672,326" fill="none" stroke="#d89b4d" stroke-width="2.2" stroke-opacity="0.5" stroke-linecap="round"/>
+<path d="M672,326 Q722,326 772,326" fill="none" stroke="#d89b4d" stroke-width="2.2" stroke-opacity="0.5" stroke-linecap="round"/>
+<path d="M772,326 Q815,326 858,326" fill="none" stroke="#d89b4d" stroke-width="2.2" stroke-opacity="0.5" stroke-linecap="round"/>
+</g>
+<circle cx="268" cy="326" r="5" fill="#140f0a" stroke="#f0c479" stroke-opacity="0.7" stroke-width="1.5"/>
+<circle cx="372" cy="250" r="5" fill="#140f0a" stroke="#f0c479" stroke-opacity="0.7" stroke-width="1.5"/>
+<circle cx="384" cy="326" r="5" fill="#140f0a" stroke="#f0c479" stroke-opacity="0.7" stroke-width="1.5"/>
+<circle cx="372" cy="404" r="5" fill="#140f0a" stroke="#f0c479" stroke-opacity="0.7" stroke-width="1.5"/>
+<circle cx="506" cy="326" r="5" fill="#140f0a" stroke="#f0c479" stroke-opacity="0.7" stroke-width="1.5"/>
+<circle cx="672" cy="326" r="5" fill="#140f0a" stroke="#f0c479" stroke-opacity="0.7" stroke-width="1.5"/>
+<circle cx="772" cy="326" r="5" fill="#140f0a" stroke="#f0c479" stroke-opacity="0.7" stroke-width="1.5"/>
+<circle cx="227" cy="326" r="8.2" fill="#ffcf7a" opacity="0.5" filter="url(#glow)"/>
+<circle cx="227" cy="326" r="2.4" fill="#fff3d6"/>
+<circle cx="330" cy="308" r="8.2" fill="#ffcf7a" opacity="0.5" filter="url(#glow)"/>
+<circle cx="330" cy="308" r="2.4" fill="#fff3d6"/>
+<circle cx="734" cy="326" r="8.2" fill="#ffcf7a" opacity="0.5" filter="url(#glow)"/>
+<circle cx="734" cy="326" r="2.4" fill="#fff3d6"/>
+<circle cx="467" cy="326" r="8.2" fill="#ffcf7a" opacity="0.5" filter="url(#glow)"/>
+<circle cx="467" cy="326" r="2.4" fill="#fff3d6"/>
+<circle cx="452" cy="385" r="8.2" fill="#ffcf7a" opacity="0.5" filter="url(#glow)"/>
+<circle cx="452" cy="385" r="2.4" fill="#fff3d6"/>
+<circle cx="646" cy="326" r="8.2" fill="#ffcf7a" opacity="0.5" filter="url(#glow)"/>
+<circle cx="646" cy="326" r="2.4" fill="#fff3d6"/>
+<rect x="96" y="292" width="86" height="64" rx="7" fill="url(#panel)" stroke="#ffdca0" stroke-opacity="0.5" stroke-width="1.5"/>
+<path d="M98,296 L139.0,324.0 L180,296" fill="none" stroke="#ffdca0" stroke-opacity="0.55" stroke-width="1.5"/>
+<rect x="548" y="230" width="40" height="192" rx="10" fill="url(#screen)" opacity="0.16"/>
+<rect x="548" y="230" width="40" height="192" rx="10" fill="none" stroke="#ffdca0" stroke-opacity="0.5" stroke-width="1.5"/>
+<path d="M568,296 l16,7 v14 q0,15 -16,23 q-16,-8 -16,-23 v-14 z" fill="none" stroke="#ffe7b0" stroke-opacity="0.8" stroke-width="1.6"/>
+<path d="M561,324 l5,6 l10,-12" fill="none" stroke="#ffe7b0" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<rect x="554" y="360" width="7" height="9" rx="1.5" fill="#1a1310"/>
+<rect x="564" y="360" width="7" height="9" rx="1.5" fill="#1a1310"/>
+<rect x="574" y="360" width="7" height="9" rx="1.5" fill="#1a1310"/>
+<circle cx="544" cy="326" r="8.8" fill="#ffcf7a" opacity="0.5" filter="url(#glow)"/>
+<circle cx="544" cy="326" r="2.6" fill="#fff3d6"/>
+<ellipse cx="960" cy="326" rx="150" ry="120" fill="url(#heart)" filter="url(#softbig)"/>
+<rect x="862" y="262" width="196" height="128" rx="12" fill="url(#panel)" stroke="#ffdca0" stroke-opacity="0.55" stroke-width="1.5"/>
+<rect x="882" y="284" width="86" height="22" rx="11" fill="url(#screen)" opacity="0.95"/>
+<circle cx="895" cy="295" r="4" fill="#3a2a16"/>
+<rect x="882" y="322" width="140" height="7" rx="3.5" fill="#e0a24c" opacity="0.50"/>
+<rect x="882" y="342" width="112" height="7" rx="3.5" fill="#e0a24c" opacity="0.42"/>
+<rect x="882" y="362" width="84" height="7" rx="3.5" fill="#e0a24c" opacity="0.34"/>
+<g>
+<circle cx="486" cy="236" r="1.4" fill="#f4c983" opacity="0.27" filter="url(#glow)"/>
+<circle cx="653" cy="221" r="0.9" fill="#f4c983" opacity="0.30" filter="url(#glow)"/>
+<circle cx="145" cy="102" r="1.1" fill="#f4c983" opacity="0.49" filter="url(#glow)"/>
+<circle cx="621" cy="284" r="2.0" fill="#f4c983" opacity="0.46" filter="url(#glow)"/>
+<circle cx="710" cy="154" r="1.5" fill="#f4c983" opacity="0.28" filter="url(#glow)"/>
+<circle cx="1116" cy="74" r="1.3" fill="#f4c983" opacity="0.39" filter="url(#glow)"/>
+<circle cx="745" cy="289" r="1.8" fill="#f4c983" opacity="0.23" filter="url(#glow)"/>
+<circle cx="994" cy="435" r="0.8" fill="#f4c983" opacity="0.27" filter="url(#glow)"/>
+<circle cx="497" cy="217" r="1.5" fill="#f4c983" opacity="0.24" filter="url(#glow)"/>
+<circle cx="795" cy="421" r="2.0" fill="#f4c983" opacity="0.45" filter="url(#glow)"/>
+<circle cx="347" cy="365" r="1.8" fill="#f4c983" opacity="0.36" filter="url(#glow)"/>
+<circle cx="822" cy="177" r="1.8" fill="#f4c983" opacity="0.23" filter="url(#glow)"/>
+<circle cx="697" cy="167" r="1.5" fill="#f4c983" opacity="0.16" filter="url(#glow)"/>
+<circle cx="445" cy="380" r="1.1" fill="#f4c983" opacity="0.41" filter="url(#glow)"/>
+</g>
+<rect width="1200" height="675" fill="url(#vig)"/>
+<rect width="1200" height="675" filter="url(#grain)" opacity="0.05"/>
+<text x="60" y="622" font-family="Mo" font-size="12" letter-spacing="3" fill="#e8b968" fill-opacity="0.55">FIELD NOTES</text>
+<text x="1140" y="622" text-anchor="end" font-family="Mo" font-size="12" letter-spacing="2" fill="#e8b968" fill-opacity="0.38">03 / 06</text>
+</svg>

--- a/beta/public/images/blog/skills-als-apps-plugin-marktplatz-light.svg
+++ b/beta/public/images/blog/skills-als-apps-plugin-marktplatz-light.svg
@@ -1,0 +1,128 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 675" width="1200" height="675" role="img" aria-label="Konzept (hell): ein Marktplatz aus App-Kacheln; per Sprache aktiviert, laeuft als derselbe Code fuer Laptop, Container und CI">
+<defs>
+<style>@font-face{font-family:'Mo';src:url(data:font/woff2;base64,d09GMgABAAAAAA7QAA8AAAAAHEwAAA53AAGzMwAAAAAAAAAAAAAAAAAAAAAAAAAAGigbIBwqBmA/U1RBVEgAgX4RCAqsLKJ4ATYCJAOCTguBKgAEIAVmByAb5RWjolZyVsaI/uKAJ0MfBYTACKR2WmgcqlNCrcK+9m3czlmg3OwcHiCxvo6QZPbncdv/GWET8qJtEERBQImSHOxSEy4D5oysF+n7WcHPCHmA7t3721fDDjigCbQtoDzwkMOAozGBw67/AcA5+31rZVXPhOpPB4AUsDtw9+LTsEznE561Gxt1gDZhjaQWB8+J0MAycHtU/O9aafMPyBVQIQrZs301proS/yazu8nm/l7miHgKQG6riFzVTAFIWJa1FfKUqxCyklRf5gzEKs6tRLzvreZMHlPkAjmAW1N4Du46AgGgyKk1jwChGpTK4D5GrWGMkYPXe9kCO5Ug5nNhDHkEAGAdmFjlMxWUeFcn3hdnxmBrLQA3QZrmkxSAd/QqCCC0mIfYkT5xVvASyK94+l74Tq/FLLxheEgIG/nf/d9CMOZjFN8MeDUvC5TJMbV9Hh6AjXdWVXaoD8xUE/+FsQk5KkEN+IxnJye9uSdiRRhSOCO4ilwNdTXBxgh8/TFrlBEoUEZFy8LKLSaJNWvJnc4urh6+fv4NG9fXAZRRqlUPa+5BY3SaU0pzLwCx4viQUqUOeQCcbOwYK62ceZuJByicVqLMx0aiKBElypSrUKmKnEI1FbVadTS0dPQMGhiZEIiIBAAAnsJV3v0gZ0uQ3wOAFQMcgOL1ivAhjlwQn/HSiTz8pMi5AEJMxSRQY3men2qBU0UMz7qKfQw4lnx6r0ogy88vKcwvKqyWFhULrmfPlRZJpaJ8gbR4S74uT5YnLcovqC7aIi6xLltziwTloi0iSRG3qN4qLdosXnps06qLBJtyRV9NgeBbz0JBhbaQL68Qt2MP/nIEuYLLlsmWZ9QE8shKLuO9ttiCZy/Fz1CY+dyIS0z7uftJACYXe9/Y/iedxprdSK/bUKx8ZeOtFAKsebAp5io0RXQV2J5VenvFaaPzm0zOCUOJu7Am0EPN6KkAoQTTowa89RHWJCGIR7rzTQwHZt748VxHozbUqbvVQRbmUjmn67cgK3mmMunc5v4tfnHrUKiD32TpDJ8HdRnpTLGoIACnTiHpiLvY5wJ+9NbB0chacSv6Lxehu16fy2+ZCD92Y3/olTmCVH7KSEFbvUV4F4nJwtURVqcj5xxlmMBMHpVBOoVkGomkpBI6wLdU4HbEmhqarA39ve9+0juOO9mPJooBQM+h9MK7k1g6QtKazfdEvK41/ZOHjJwR6uhi7jdUwZnDq3lnzEa+JmNzztm1jpGleR+Gh19qljughLpWO3nkE0VeMqfscHpK1zDYUssByGubUJhiTdUnn/TL62V+5hePkNMus4fMMLVm+U3ui2IL1MHVOl9JYHiI4soOpnVLBRKxXDU5xywqC+NHmqC8iUmKM9S9pZt1h7qXwgJHdDnswU3Q8hAimT+AvjmKagdZvZWidvQCZyj5LGQpqe+LtAT/QOWDnTsvwf9zuHzm9f0eCX+WgTHlWgXswYnnFhreUDOYetavvyVd/ndO0Vd48OiEWcj+Sm+hmP25PRp90SADQaHPzzdHf2gVGBiyqjHSVzBJR+l1pQDVWFPU1obCB4Yzj0mdeYh1nqQSrTbJ+jRnXkKFOHZTqrVZWgRcb72sciG+biu29/Ieg3tdfM0ISQqtJf7f/v6w/d+W/YwjGvOf9GEt/aNJ6jeHMuZv3t7uePVMwz2yjiOuI14iqaSDUAotbndJ0pqixMHF/R8xEP2BzpG4cuUNzcW42HRfEiZz7dXwIiKf4I/8dfsQd45FzvZpTG3B6UMxMHH5PH7iL7Qasj3U2swLBlkvLmTsQ9zzrIkqdlFxXDnPY2iaGNRSJoRMhzFK5U/enLOSo5Mf3nvmyeFun1c10qd2JcTwxwNs9snZuX62VuUPVetznGmVJtTA7RmcPCZxXCRoM1pCTeg4PIe8lkaj14LmoE6SnM3YL5+atl8+yybbDixtGm0RSsPxiNkS9lTv5Vqq94Q9FmcyKcasQDZz6CCw2au4tTi6YGoKnb/WzDUnIgNTh48cmVobiACbvQmzn0Xj0S+6MPRk74ofs7CNjtN6UElCM3HvZUvTzstn2YS7x+LtE3syQqk7mmgyRTzKvVyLak/UYzEEG1RtO6+J/91P86+cf7k+Fq4Fe5bJ3HzczRkmy7TK/q1A45tLbsZ3Lb4BkEnIfpt1jECJXF6SSiCEcPJN5s251SNw5KMZw/jQV49nmWzDH/33yy+HnixzwbXHYxDGDsnz5pjs/mMDSnzg/iwzl3dIDmR2qWDt4+OYresnx4NagmeS9svnFghZY5y0MHePRMIUdlXvaW2t3ht2m3zpRh/IPTk3YLNvolGDrcPnI5TPhPZvHFjAMZ/LHfPiBVie20czy+Fd3sf3WlS/qoObB8k5I38xE/smuvV14YA6biP5pE3oLX6GkT5UtubRnFYytR9FPA5nxI32g1ESmnb4R4SBjLBHQyG5Xu/dWlZZ8SGuiW+mNrJ6ZbDRbmYH9RTVb7X35royQlbuccvrPRGnofxpqswjY7b02WqbbWYHM6oFYuotnIffmgK1ZGLP8UvPM8+noy2hEKm0K5cyPeDX0ePc/cdvfSTnuMFI5HHWfWpBxMuBLADJhiX7Ke1W7An6R3se7Og5ZadapuvBzke7e84oWwZ4FW9d2nVxyLPrjUsrQM8cu2MJv31+B6dh+KxQH6usc6l9NGKkN1f67G6L6cX70zliNMGxHYNTve/K/pNWIPqkoorPJnKknWSsRE4ZA1WVnlrNxaWZs8rlSggX1vh3bHz0ecF8OIsVB9d+8JfWkL1e43IyaZB/kijmDQ+2cOEBt86vqUo57VVpnxYshWjUa1vB2LY86kO2lhpb8zUp4W2k2UDFBzguPkAZkO3elPAaB9OqhYJCjv/wpNpX+sPaQQXOhgXzz99a5d9RFav3aavSdmdVyq/RucMDXEt4EHSFoRGvdQVj6/KQj/IPumzLmW37BZhO+hs89U9kcjaSM+z3PoUwHAnYHFEErzYEgih0DbqmNKe84aMn0CMIlBdbWuQO//Up4W1PO4Jhi5VRJXQN3gG3dToUtkz1uT3mtGEHpr93mtL9GiTyNbdBc05V1FejIcNt8Xi0DXqyWHXyuX/4t6ssUb2StSWxI2KkzK5wBNmBRq9dufYrKn3yTnQnhtHT0VXVnfXfrG1CLhkVCNPAZvFLxM6JFz98u77v+j/6R48B6a7tZYayVbSPQojaqNyFPkSglEV4sycfY/VptHqv0F1wvDNQ77Kk+jowDrxZtulvVV0cY98z5XsbcPcHHz7rgjC1S+WgG1WsOYkdyBK2q9wVCo/OAepCauTZsCRyiMLTlpPYttIyGKPoAY4joibPArHTr4oS87c7uCZHrCeiXaUoQLhXTEXuIPbdn3f6W/5of2srjJZf41FXpdzuypRXDbmn47z79xHkDlUTNyfXVHc7MR/96jltL1TigUwa+m8FsOjWIy+s3YpezD1+Ntfn9VhGwyPV0XtqS+ZfRNBY6O/WmmldSjhBmppsrvKqLa23nR0WMUqHWlMXyKjcnrTGEF5NCVsKglXW1YodF57yR3NRRmmr1Ro9bZVA/+5t7OxocHeN9sZ9SYYUwC2sTp8wth0YXnDRrhh2uGqGwiXW2lit09/UqL3HaQ8E3b/DUiQUQP/if+WyyhPQa0+g1xHkFMZah9qS2BkxBi3OAB2wYxl9ICtxZUj443sxd/69t+QwB1YH/Brf3ZHx+INvC66/eMgfWZ4FjI9I7iK6jnniyBM9d/If0l2nvCbeF46cjhw7L+oq3/VYLnfR3Wfczb2Ov76zEeI4Nk2iS5aeaQTzvVv+i/HNst2TkYmM7fKp6RYTbCQ6zrKZngK38UwkoSf9ir2pjEDI1esCfkImhfD/BnaK70Edis9iSjJrxB9i0Ic0C3Ojg6b8e2+ukv/+gzbERAoCGWFh/5HlaarfYOQcxsoo9lKKnxh/rWv7MRjkkunlMUEqLRS6sMmlDm39sl57XnCnxozN8tdcSpPf7PH6GscywvzYfFe/v1djTNo8cZoWy5j83v6oz90+rYOD53DR5Hvcmwxmzsl8J+gAlcTfp7NnUEa4HLU7/HEc0lcGPQptTVgp5DQnLGF1qXD9f9Onpb4+p3k0EHCMjTigTkJPBK3H96Z3nu2aGfLEmlIqY+ilTO7dF9tsCY/mENGz4dIRuspA9tssI1TUOTFmDyTIZDqG6KS3PqRQB3Q6RShQAw+N2d+efC7K7scfRj2hjtMdZ+26hAW1hJzUulv9kZaeUPGGh1DYYzalOvRNTZ16Y8rsocIvbggXsz0Rv7t1QksmyIzL64whOkYjpzfj8nMWn9li8NhsVq/NAHmgek3fFR/Xtxo3W23YUzdm3E6umqIpmnnO75dWluCHixsvNi4tTNiuheHRDXyOpmeF+X9iAzHY8G+0PgrdoxEfPqHsJIoSKH2yByITJ5afEAxij8QJKAC/zGOLnj8n4kRE4vqt4aqernQXQ2mwPuXvP4AYkwtxdVuUXJp8C5SwnNCPJK3ESYldMTVR7dHapDjEmKL+0pQgRmUQ+9l7wS+nwbWPcO3dC1sBYDsAz8lfBsX6jzy9ADvs9Dau/8pT8J4gGoBXL6aPrQ/xXcqahxLJQiLxZ8n3AMSu/gX4RY869bLErYaidWdtu8T+Wx6f/yUBwGfpa1Jws1+l//9l/H+Od4KgAsK891bWuzHDS1cT/rtPkBynmgTxKz1mwvYrsKCIZaknDXagSYmhB/RElm+voAK5XW1dAVRyBT0pgYwALJH51IQDKoiexo4RWwZKwGQFokUSix1pYgE2ghEaKJ5HdhbWm7upfAD4nn6c8CuM0ILI0EUwWjHg6gQQAHDypxqDihBOmp/OEzCiAXk+8IgBXowAKCIGeex2rXiLes+4Xv1mjeg0JWVXg9ZrwAzKjE4jonW3uHGjEB57Tzp5fY1OBoQT) format('woff2');}</style>
+<radialGradient id="ground" cx="46%" cy="48%" r="80%">
+  <stop offset="0%" stop-color="#fdfaf3"/><stop offset="58%" stop-color="#f3ecdb"/><stop offset="100%" stop-color="#e4d9c1"/>
+</radialGradient>
+<radialGradient id="coreglow" cx="50%" cy="50%" r="50%">
+  <stop offset="0%" stop-color="#ffdd93" stop-opacity="0.55"/><stop offset="55%" stop-color="#f2c46a" stop-opacity="0.16"/><stop offset="100%" stop-color="#f0ab4c" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="heart" cx="50%" cy="50%" r="50%">
+  <stop offset="0%" stop-color="#ffe3a0" stop-opacity="0.55"/><stop offset="60%" stop-color="#f0ab4c" stop-opacity="0.12"/><stop offset="100%" stop-color="#f0ab4c" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="halo" cx="50%" cy="50%" r="50%">
+  <stop offset="0%" stop-color="#f6bf5c" stop-opacity="0.7"/><stop offset="100%" stop-color="#f6bf5c" stop-opacity="0"/>
+</radialGradient>
+<linearGradient id="cell" x1="0" y1="0" x2="0" y2="1">
+  <stop offset="0%" stop-color="#f0b957"/><stop offset="55%" stop-color="#d5923c"/><stop offset="100%" stop-color="#b0742c"/>
+</linearGradient>
+<linearGradient id="hot" x1="0" y1="0" x2="0" y2="1">
+  <stop offset="0%" stop-color="#ffe6a6"/><stop offset="50%" stop-color="#f6c065"/><stop offset="100%" stop-color="#dc9d3e"/>
+</linearGradient>
+<linearGradient id="screen" x1="0" y1="0" x2="0" y2="1">
+  <stop offset="0%" stop-color="#ffe7ad"/><stop offset="100%" stop-color="#e6ab52"/>
+</linearGradient>
+<linearGradient id="panel" x1="0" y1="0" x2="0" y2="1">
+  <stop offset="0%" stop-color="#fffaf0"/><stop offset="100%" stop-color="#f4e8d0"/>
+</linearGradient>
+<radialGradient id="vig" cx="50%" cy="46%" r="66%">
+  <stop offset="62%" stop-color="#8a6a34" stop-opacity="0"/><stop offset="100%" stop-color="#8a6a34" stop-opacity="0.16"/>
+</radialGradient>
+<filter id="glow" x="-120%" y="-120%" width="340%" height="340%"><feGaussianBlur stdDeviation="6"/></filter>
+<filter id="glowbig" x="-150%" y="-150%" width="400%" height="400%"><feGaussianBlur stdDeviation="11"/></filter>
+<filter id="softbig" x="-60%" y="-60%" width="220%" height="220%"><feGaussianBlur stdDeviation="24"/></filter>
+<filter id="lift" x="-40%" y="-40%" width="180%" height="200%"><feDropShadow dx="0" dy="6" stdDeviation="11" flood-color="#6e4e24" flood-opacity="0.26"/></filter>
+<filter id="grain"><feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="2" stitchTiles="stitch"/>
+  <feColorMatrix type="matrix" values="0 0 0 0 0.42  0 0 0 0 0.30  0 0 0 0 0.12  0 0 0 0.5 0"/></filter>
+</defs>
+<rect width="1200" height="675" fill="url(#ground)"/>
+<ellipse cx="360" cy="300" rx="300" ry="250" fill="url(#coreglow)" filter="url(#softbig)"/>
+<polygon points="277.0,196.0 263.5,219.4 236.5,219.4 223.0,196.0 236.5,172.6 263.5,172.6" fill="none" stroke="#b07a34" stroke-opacity="0.35" stroke-width="1"/>
+<circle cx="250.0" cy="196.0" r="3.2" fill="#3a2a16" opacity="0.3"/>
+<polygon points="277.0,242.8 263.5,266.1 236.5,266.1 223.0,242.8 236.5,219.4 263.5,219.4" fill="none" stroke="#b07a34" stroke-opacity="0.35" stroke-width="1"/>
+<circle cx="250.0" cy="242.7653718043597" r="3.2" fill="#3a2a16" opacity="0.3"/>
+<polygon points="277.0,289.5 263.5,312.9 236.5,312.9 223.0,289.5 236.5,266.1 263.5,266.1" fill="url(#cell)" fill-opacity="0.85" stroke="#9a6a28" stroke-opacity="0.5" stroke-width="1"/>
+<circle cx="250.0" cy="289.5307436087194" r="3.2" fill="#3a2a16" opacity="0.55"/>
+<polygon points="277.0,336.3 263.5,359.7 236.5,359.7 223.0,336.3 236.5,312.9 263.5,312.9" fill="none" stroke="#b07a34" stroke-opacity="0.35" stroke-width="1"/>
+<circle cx="250.0" cy="336.29611541307906" r="3.2" fill="#3a2a16" opacity="0.3"/>
+<polygon points="317.5,219.4 304.0,242.8 277.0,242.8 263.5,219.4 277.0,196.0 304.0,196.0" fill="url(#cell)" fill-opacity="0.85" stroke="#9a6a28" stroke-opacity="0.5" stroke-width="1"/>
+<circle cx="290.5" cy="219.38268590217984" r="3.2" fill="#3a2a16" opacity="0.55"/>
+<polygon points="317.5,266.1 304.0,289.5 277.0,289.5 263.5,266.1 277.0,242.8 304.0,242.8" fill="none" stroke="#b07a34" stroke-opacity="0.35" stroke-width="1"/>
+<circle cx="290.5" cy="266.14805770653953" r="3.2" fill="#3a2a16" opacity="0.3"/>
+<polygon points="317.5,312.9 304.0,336.3 277.0,336.3 263.5,312.9 277.0,289.5 304.0,289.5" fill="none" stroke="#b07a34" stroke-opacity="0.35" stroke-width="1"/>
+<circle cx="290.5" cy="312.9134295108992" r="3.2" fill="#3a2a16" opacity="0.3"/>
+<polygon points="317.5,359.7 304.0,383.1 277.0,383.1 263.5,359.7 277.0,336.3 304.0,336.3" fill="none" stroke="#b07a34" stroke-opacity="0.35" stroke-width="1"/>
+<circle cx="290.5" cy="359.6788013152589" r="3.2" fill="#3a2a16" opacity="0.3"/>
+<polygon points="358.0,196.0 344.5,219.4 317.5,219.4 304.0,196.0 317.5,172.6 344.5,172.6" fill="none" stroke="#b07a34" stroke-opacity="0.35" stroke-width="1"/>
+<circle cx="331.0" cy="196.0" r="3.2" fill="#3a2a16" opacity="0.3"/>
+<ellipse cx="331" cy="243" rx="60" ry="55" fill="url(#heart)" filter="url(#softbig)"/>
+<polygon points="358.0,242.8 344.5,266.1 317.5,266.1 304.0,242.8 317.5,219.4 344.5,219.4" fill="url(#hot)" stroke="#9a6a28" stroke-opacity="0.7" stroke-width="1.2"/>
+<circle cx="331.0" cy="242.7653718043597" r="3.2" fill="#3a2a16" opacity="0.55"/>
+<polygon points="358.0,289.5 344.5,312.9 317.5,312.9 304.0,289.5 317.5,266.1 344.5,266.1" fill="url(#cell)" fill-opacity="0.85" stroke="#9a6a28" stroke-opacity="0.5" stroke-width="1"/>
+<circle cx="331.0" cy="289.5307436087194" r="3.2" fill="#3a2a16" opacity="0.55"/>
+<polygon points="358.0,336.3 344.5,359.7 317.5,359.7 304.0,336.3 317.5,312.9 344.5,312.9" fill="none" stroke="#b07a34" stroke-opacity="0.35" stroke-width="1"/>
+<circle cx="331.0" cy="336.29611541307906" r="3.2" fill="#3a2a16" opacity="0.3"/>
+<polygon points="398.5,219.4 385.0,242.8 358.0,242.8 344.5,219.4 358.0,196.0 385.0,196.0" fill="url(#cell)" fill-opacity="0.85" stroke="#9a6a28" stroke-opacity="0.5" stroke-width="1"/>
+<circle cx="371.5" cy="219.38268590217984" r="3.2" fill="#3a2a16" opacity="0.55"/>
+<polygon points="398.5,266.1 385.0,289.5 358.0,289.5 344.5,266.1 358.0,242.8 385.0,242.8" fill="none" stroke="#b07a34" stroke-opacity="0.35" stroke-width="1"/>
+<circle cx="371.5" cy="266.14805770653953" r="3.2" fill="#3a2a16" opacity="0.3"/>
+<polygon points="398.5,312.9 385.0,336.3 358.0,336.3 344.5,312.9 358.0,289.5 385.0,289.5" fill="none" stroke="#b07a34" stroke-opacity="0.35" stroke-width="1"/>
+<circle cx="371.5" cy="312.9134295108992" r="3.2" fill="#3a2a16" opacity="0.3"/>
+<polygon points="398.5,359.7 385.0,383.1 358.0,383.1 344.5,359.7 358.0,336.3 385.0,336.3" fill="url(#cell)" fill-opacity="0.85" stroke="#9a6a28" stroke-opacity="0.5" stroke-width="1"/>
+<circle cx="371.5" cy="359.6788013152589" r="3.2" fill="#3a2a16" opacity="0.55"/>
+<polygon points="439.0,196.0 425.5,219.4 398.5,219.4 385.0,196.0 398.5,172.6 425.5,172.6" fill="none" stroke="#b07a34" stroke-opacity="0.35" stroke-width="1"/>
+<circle cx="412.0" cy="196.0" r="3.2" fill="#3a2a16" opacity="0.3"/>
+<polygon points="439.0,242.8 425.5,266.1 398.5,266.1 385.0,242.8 398.5,219.4 425.5,219.4" fill="url(#cell)" fill-opacity="0.85" stroke="#9a6a28" stroke-opacity="0.5" stroke-width="1"/>
+<circle cx="412.0" cy="242.7653718043597" r="3.2" fill="#3a2a16" opacity="0.55"/>
+<polygon points="439.0,289.5 425.5,312.9 398.5,312.9 385.0,289.5 398.5,266.1 425.5,266.1" fill="none" stroke="#b07a34" stroke-opacity="0.35" stroke-width="1"/>
+<circle cx="412.0" cy="289.5307436087194" r="3.2" fill="#3a2a16" opacity="0.3"/>
+<polygon points="439.0,336.3 425.5,359.7 398.5,359.7 385.0,336.3 398.5,312.9 425.5,312.9" fill="none" stroke="#b07a34" stroke-opacity="0.35" stroke-width="1"/>
+<circle cx="412.0" cy="336.29611541307906" r="3.2" fill="#3a2a16" opacity="0.3"/>
+<g filter="url(#lift)"><rect x="244" y="84" width="104" height="40" rx="12" fill="url(#panel)" stroke="#9a6a28" stroke-opacity="0.55" stroke-width="1.3"/></g>
+<path d="M276,122 l0,14 l16,-14 z" fill="url(#panel)" stroke="#9a6a28" stroke-opacity="0.55" stroke-width="1.3"/>
+<rect x="256" y="96" width="64" height="5" rx="2.5" fill="#b5822f" opacity="0.6"/>
+<rect x="256" y="108" width="42" height="5" rx="2.5" fill="#b5822f" opacity="0.6"/>
+<path d="M288,124 L331,243" stroke="#b07d33" stroke-width="2" stroke-opacity="0.7" stroke-dasharray="1 6" stroke-linecap="round"/>
+<path d="M371,243 Q600,243 828,196" fill="none" stroke="#b07a34" stroke-width="2" stroke-opacity="0.5" stroke-linecap="round"/>
+<circle cx="639" cy="227" r="5.7" fill="url(#halo)" filter="url(#glow)"/>
+<circle cx="639" cy="227" r="2.2" fill="#d59433" stroke="#8a5a20" stroke-opacity="0.4" stroke-width="0.6"/>
+<circle cx="638.5" cy="226.0" r="0.9" fill="#fff3d6"/>
+<path d="M371,243 Q606,243 840,340" fill="none" stroke="#b07a34" stroke-width="2" stroke-opacity="0.5" stroke-linecap="round"/>
+<circle cx="663" cy="280" r="5.7" fill="url(#halo)" filter="url(#glow)"/>
+<circle cx="663" cy="280" r="2.2" fill="#d59433" stroke="#8a5a20" stroke-opacity="0.4" stroke-width="0.6"/>
+<circle cx="662.3" cy="279.8" r="0.9" fill="#fff3d6"/>
+<path d="M371,243 Q600,243 828,486" fill="none" stroke="#b07a34" stroke-width="2" stroke-opacity="0.5" stroke-linecap="round"/>
+<circle cx="663" cy="342" r="5.7" fill="url(#halo)" filter="url(#glow)"/>
+<circle cx="663" cy="342" r="2.2" fill="#d59433" stroke="#8a5a20" stroke-opacity="0.4" stroke-width="0.6"/>
+<circle cx="662.2" cy="341.3" r="0.9" fill="#fff3d6"/>
+<ellipse cx="880" cy="196" rx="90" ry="80" fill="url(#coreglow)" filter="url(#softbig)"/>
+<g filter="url(#lift)"><rect x="842" y="170" width="76" height="48" rx="6" fill="url(#panel)" stroke="#9a6a28" stroke-opacity="0.6" stroke-width="1.4"/></g>
+<rect x="852" y="179" width="56" height="30" rx="3" fill="url(#screen)"/>
+<path d="M832,226 l96,0 l6,6 l-108,0 z" fill="#c99236" opacity="0.6"/>
+<ellipse cx="892" cy="340" rx="90" ry="80" fill="url(#coreglow)" filter="url(#softbig)"/>
+<g filter="url(#lift)"><rect x="858" y="310" width="68" height="60" rx="7" fill="url(#panel)" stroke="#9a6a28" stroke-opacity="0.6" stroke-width="1.4"/></g>
+<polygon points="905.0,338.0 898.5,349.3 885.5,349.3 879.0,338.0 885.5,326.7 898.5,326.7" fill="none" stroke="#9a6a28" stroke-opacity="0.7" stroke-width="1.4"/>
+<line x1="870" y1="362" x2="914" y2="362" stroke="#9a6a28" stroke-opacity="0.2"/>
+<ellipse cx="880" cy="486" rx="90" ry="80" fill="url(#coreglow)" filter="url(#softbig)"/>
+<g filter="url(#lift)"><circle cx="880" cy="486" r="31" fill="url(#panel)" stroke="#9a6a28" stroke-opacity="0.5" stroke-width="1.4"/></g>
+<path d="M900,486 Q895,512 870,503" fill="none" stroke="#b07d33" stroke-opacity="0.85" stroke-width="2" stroke-linecap="round"/>
+<path d="M876,503 L870,503 L873,508" fill="none" stroke="#b07d33" stroke-opacity="0.85" stroke-width="2"/>
+<path d="M860,486 Q865,460 890,469" fill="none" stroke="#b07d33" stroke-opacity="0.85" stroke-width="2" stroke-linecap="round"/>
+<path d="M884,469 L890,469 L887,464" fill="none" stroke="#b07d33" stroke-opacity="0.85" stroke-width="2"/>
+<g>
+<circle cx="276" cy="266" r="1.2" fill="#d59a44" opacity="0.45"/>
+<circle cx="268" cy="286" r="1.9" fill="#d59a44" opacity="0.32"/>
+<circle cx="739" cy="360" r="1.5" fill="#d59a44" opacity="0.39"/>
+<circle cx="495" cy="208" r="2.0" fill="#d59a44" opacity="0.32"/>
+<circle cx="750" cy="410" r="1.0" fill="#d59a44" opacity="0.28"/>
+<circle cx="426" cy="394" r="1.2" fill="#d59a44" opacity="0.38"/>
+<circle cx="355" cy="382" r="1.9" fill="#d59a44" opacity="0.43"/>
+<circle cx="244" cy="372" r="1.4" fill="#d59a44" opacity="0.45"/>
+<circle cx="421" cy="432" r="2.0" fill="#d59a44" opacity="0.45"/>
+<circle cx="649" cy="396" r="1.6" fill="#d59a44" opacity="0.25"/>
+</g>
+<rect width="1200" height="675" fill="url(#vig)"/>
+<rect width="1200" height="675" filter="url(#grain)" opacity="0.04"/>
+<text x="60" y="622" font-family="Mo" font-size="12" letter-spacing="3" fill="#9a6a2c" fill-opacity="0.8">FIELD NOTES</text>
+<text x="1140" y="622" text-anchor="end" font-family="Mo" font-size="12" letter-spacing="2" fill="#9a6a2c" fill-opacity="0.55">04 / 06</text>
+</svg>

--- a/beta/public/images/blog/skills-als-apps-plugin-marktplatz.svg
+++ b/beta/public/images/blog/skills-als-apps-plugin-marktplatz.svg
@@ -1,0 +1,134 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 675" width="1200" height="675" role="img" aria-label="Konzept: ein Marktplatz aus App-Kacheln; per natuerlicher Sprache wird ein Skill aktiviert und laeuft als derselbe Code fuer Laptop, Container und CI">
+<defs>
+<style>@font-face{font-family:'Mo';src:url(data:font/woff2;base64,d09GMgABAAAAAA7QAA8AAAAAHEwAAA53AAGzMwAAAAAAAAAAAAAAAAAAAAAAAAAAGigbIBwqBmA/U1RBVEgAgX4RCAqsLKJ4ATYCJAOCTguBKgAEIAVmByAb5RWjolZyVsaI/uKAJ0MfBYTACKR2WmgcqlNCrcK+9m3czlmg3OwcHiCxvo6QZPbncdv/GWET8qJtEERBQImSHOxSEy4D5oysF+n7WcHPCHmA7t3721fDDjigCbQtoDzwkMOAozGBw67/AcA5+31rZVXPhOpPB4AUsDtw9+LTsEznE561Gxt1gDZhjaQWB8+J0MAycHtU/O9aafMPyBVQIQrZs301proS/yazu8nm/l7miHgKQG6riFzVTAFIWJa1FfKUqxCyklRf5gzEKs6tRLzvreZMHlPkAjmAW1N4Du46AgGgyKk1jwChGpTK4D5GrWGMkYPXe9kCO5Ug5nNhDHkEAGAdmFjlMxWUeFcn3hdnxmBrLQA3QZrmkxSAd/QqCCC0mIfYkT5xVvASyK94+l74Tq/FLLxheEgIG/nf/d9CMOZjFN8MeDUvC5TJMbV9Hh6AjXdWVXaoD8xUE/+FsQk5KkEN+IxnJye9uSdiRRhSOCO4ilwNdTXBxgh8/TFrlBEoUEZFy8LKLSaJNWvJnc4urh6+fv4NG9fXAZRRqlUPa+5BY3SaU0pzLwCx4viQUqUOeQCcbOwYK62ceZuJByicVqLMx0aiKBElypSrUKmKnEI1FbVadTS0dPQMGhiZEIiIBAAAnsJV3v0gZ0uQ3wOAFQMcgOL1ivAhjlwQn/HSiTz8pMi5AEJMxSRQY3men2qBU0UMz7qKfQw4lnx6r0ogy88vKcwvKqyWFhULrmfPlRZJpaJ8gbR4S74uT5YnLcovqC7aIi6xLltziwTloi0iSRG3qN4qLdosXnps06qLBJtyRV9NgeBbz0JBhbaQL68Qt2MP/nIEuYLLlsmWZ9QE8shKLuO9ttiCZy/Fz1CY+dyIS0z7uftJACYXe9/Y/iedxprdSK/bUKx8ZeOtFAKsebAp5io0RXQV2J5VenvFaaPzm0zOCUOJu7Am0EPN6KkAoQTTowa89RHWJCGIR7rzTQwHZt748VxHozbUqbvVQRbmUjmn67cgK3mmMunc5v4tfnHrUKiD32TpDJ8HdRnpTLGoIACnTiHpiLvY5wJ+9NbB0chacSv6Lxehu16fy2+ZCD92Y3/olTmCVH7KSEFbvUV4F4nJwtURVqcj5xxlmMBMHpVBOoVkGomkpBI6wLdU4HbEmhqarA39ve9+0juOO9mPJooBQM+h9MK7k1g6QtKazfdEvK41/ZOHjJwR6uhi7jdUwZnDq3lnzEa+JmNzztm1jpGleR+Gh19qljughLpWO3nkE0VeMqfscHpK1zDYUssByGubUJhiTdUnn/TL62V+5hePkNMus4fMMLVm+U3ui2IL1MHVOl9JYHiI4soOpnVLBRKxXDU5xywqC+NHmqC8iUmKM9S9pZt1h7qXwgJHdDnswU3Q8hAimT+AvjmKagdZvZWidvQCZyj5LGQpqe+LtAT/QOWDnTsvwf9zuHzm9f0eCX+WgTHlWgXswYnnFhreUDOYetavvyVd/ndO0Vd48OiEWcj+Sm+hmP25PRp90SADQaHPzzdHf2gVGBiyqjHSVzBJR+l1pQDVWFPU1obCB4Yzj0mdeYh1nqQSrTbJ+jRnXkKFOHZTqrVZWgRcb72sciG+biu29/Ieg3tdfM0ISQqtJf7f/v6w/d+W/YwjGvOf9GEt/aNJ6jeHMuZv3t7uePVMwz2yjiOuI14iqaSDUAotbndJ0pqixMHF/R8xEP2BzpG4cuUNzcW42HRfEiZz7dXwIiKf4I/8dfsQd45FzvZpTG3B6UMxMHH5PH7iL7Qasj3U2swLBlkvLmTsQ9zzrIkqdlFxXDnPY2iaGNRSJoRMhzFK5U/enLOSo5Mf3nvmyeFun1c10qd2JcTwxwNs9snZuX62VuUPVetznGmVJtTA7RmcPCZxXCRoM1pCTeg4PIe8lkaj14LmoE6SnM3YL5+atl8+yybbDixtGm0RSsPxiNkS9lTv5Vqq94Q9FmcyKcasQDZz6CCw2au4tTi6YGoKnb/WzDUnIgNTh48cmVobiACbvQmzn0Xj0S+6MPRk74ofs7CNjtN6UElCM3HvZUvTzstn2YS7x+LtE3syQqk7mmgyRTzKvVyLak/UYzEEG1RtO6+J/91P86+cf7k+Fq4Fe5bJ3HzczRkmy7TK/q1A45tLbsZ3Lb4BkEnIfpt1jECJXF6SSiCEcPJN5s251SNw5KMZw/jQV49nmWzDH/33yy+HnixzwbXHYxDGDsnz5pjs/mMDSnzg/iwzl3dIDmR2qWDt4+OYresnx4NagmeS9svnFghZY5y0MHePRMIUdlXvaW2t3ht2m3zpRh/IPTk3YLNvolGDrcPnI5TPhPZvHFjAMZ/LHfPiBVie20czy+Fd3sf3WlS/qoObB8k5I38xE/smuvV14YA6biP5pE3oLX6GkT5UtubRnFYytR9FPA5nxI32g1ESmnb4R4SBjLBHQyG5Xu/dWlZZ8SGuiW+mNrJ6ZbDRbmYH9RTVb7X35royQlbuccvrPRGnofxpqswjY7b02WqbbWYHM6oFYuotnIffmgK1ZGLP8UvPM8+noy2hEKm0K5cyPeDX0ePc/cdvfSTnuMFI5HHWfWpBxMuBLADJhiX7Ke1W7An6R3se7Og5ZadapuvBzke7e84oWwZ4FW9d2nVxyLPrjUsrQM8cu2MJv31+B6dh+KxQH6usc6l9NGKkN1f67G6L6cX70zliNMGxHYNTve/K/pNWIPqkoorPJnKknWSsRE4ZA1WVnlrNxaWZs8rlSggX1vh3bHz0ecF8OIsVB9d+8JfWkL1e43IyaZB/kijmDQ+2cOEBt86vqUo57VVpnxYshWjUa1vB2LY86kO2lhpb8zUp4W2k2UDFBzguPkAZkO3elPAaB9OqhYJCjv/wpNpX+sPaQQXOhgXzz99a5d9RFav3aavSdmdVyq/RucMDXEt4EHSFoRGvdQVj6/KQj/IPumzLmW37BZhO+hs89U9kcjaSM+z3PoUwHAnYHFEErzYEgih0DbqmNKe84aMn0CMIlBdbWuQO//Up4W1PO4Jhi5VRJXQN3gG3dToUtkz1uT3mtGEHpr93mtL9GiTyNbdBc05V1FejIcNt8Xi0DXqyWHXyuX/4t6ssUb2StSWxI2KkzK5wBNmBRq9dufYrKn3yTnQnhtHT0VXVnfXfrG1CLhkVCNPAZvFLxM6JFz98u77v+j/6R48B6a7tZYayVbSPQojaqNyFPkSglEV4sycfY/VptHqv0F1wvDNQ77Kk+jowDrxZtulvVV0cY98z5XsbcPcHHz7rgjC1S+WgG1WsOYkdyBK2q9wVCo/OAepCauTZsCRyiMLTlpPYttIyGKPoAY4joibPArHTr4oS87c7uCZHrCeiXaUoQLhXTEXuIPbdn3f6W/5of2srjJZf41FXpdzuypRXDbmn47z79xHkDlUTNyfXVHc7MR/96jltL1TigUwa+m8FsOjWIy+s3YpezD1+Ntfn9VhGwyPV0XtqS+ZfRNBY6O/WmmldSjhBmppsrvKqLa23nR0WMUqHWlMXyKjcnrTGEF5NCVsKglXW1YodF57yR3NRRmmr1Ro9bZVA/+5t7OxocHeN9sZ9SYYUwC2sTp8wth0YXnDRrhh2uGqGwiXW2lit09/UqL3HaQ8E3b/DUiQUQP/if+WyyhPQa0+g1xHkFMZah9qS2BkxBi3OAB2wYxl9ICtxZUj443sxd/69t+QwB1YH/Brf3ZHx+INvC66/eMgfWZ4FjI9I7iK6jnniyBM9d/If0l2nvCbeF46cjhw7L+oq3/VYLnfR3Wfczb2Ov76zEeI4Nk2iS5aeaQTzvVv+i/HNst2TkYmM7fKp6RYTbCQ6zrKZngK38UwkoSf9ir2pjEDI1esCfkImhfD/BnaK70Edis9iSjJrxB9i0Ic0C3Ojg6b8e2+ukv/+gzbERAoCGWFh/5HlaarfYOQcxsoo9lKKnxh/rWv7MRjkkunlMUEqLRS6sMmlDm39sl57XnCnxozN8tdcSpPf7PH6GscywvzYfFe/v1djTNo8cZoWy5j83v6oz90+rYOD53DR5Hvcmwxmzsl8J+gAlcTfp7NnUEa4HLU7/HEc0lcGPQptTVgp5DQnLGF1qXD9f9Onpb4+p3k0EHCMjTigTkJPBK3H96Z3nu2aGfLEmlIqY+ilTO7dF9tsCY/mENGz4dIRuspA9tssI1TUOTFmDyTIZDqG6KS3PqRQB3Q6RShQAw+N2d+efC7K7scfRj2hjtMdZ+26hAW1hJzUulv9kZaeUPGGh1DYYzalOvRNTZ16Y8rsocIvbggXsz0Rv7t1QksmyIzL64whOkYjpzfj8nMWn9li8NhsVq/NAHmgek3fFR/Xtxo3W23YUzdm3E6umqIpmnnO75dWluCHixsvNi4tTNiuheHRDXyOpmeF+X9iAzHY8G+0PgrdoxEfPqHsJIoSKH2yByITJ5afEAxij8QJKAC/zGOLnj8n4kRE4vqt4aqernQXQ2mwPuXvP4AYkwtxdVuUXJp8C5SwnNCPJK3ESYldMTVR7dHapDjEmKL+0pQgRmUQ+9l7wS+nwbWPcO3dC1sBYDsAz8lfBsX6jzy9ADvs9Dau/8pT8J4gGoBXL6aPrQ/xXcqahxLJQiLxZ8n3AMSu/gX4RY869bLErYaidWdtu8T+Wx6f/yUBwGfpa1Jws1+l//9l/H+Od4KgAsK891bWuzHDS1cT/rtPkBynmgTxKz1mwvYrsKCIZaknDXagSYmhB/RElm+voAK5XW1dAVRyBT0pgYwALJH51IQDKoiexo4RWwZKwGQFokUSix1pYgE2ghEaKJ5HdhbWm7upfAD4nn6c8CuM0ILI0EUwWjHg6gQQAHDypxqDihBOmp/OEzCiAXk+8IgBXowAKCIGeex2rXiLes+4Xv1mjeg0JWVXg9ZrwAzKjE4jonW3uHGjEB57Tzp5fY1OBoQT) format('woff2');}</style>
+<radialGradient id="ground" cx="36%" cy="50%" r="80%">
+  <stop offset="0%" stop-color="#1c1610"/><stop offset="55%" stop-color="#120e0a"/>
+  <stop offset="100%" stop-color="#090705"/>
+</radialGradient>
+<radialGradient id="coreglow" cx="50%" cy="50%" r="50%">
+  <stop offset="0%" stop-color="#f5bd62" stop-opacity="0.52"/>
+  <stop offset="45%" stop-color="#c8863c" stop-opacity="0.20"/>
+  <stop offset="100%" stop-color="#c8863c" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="heart" cx="50%" cy="50%" r="50%">
+  <stop offset="0%" stop-color="#ffdf99" stop-opacity="0.55"/>
+  <stop offset="60%" stop-color="#f0ab4c" stop-opacity="0.12"/>
+  <stop offset="100%" stop-color="#f0ab4c" stop-opacity="0"/>
+</radialGradient>
+<linearGradient id="cell" x1="0" y1="0" x2="0" y2="1">
+  <stop offset="0%" stop-color="#eab866"/><stop offset="52%" stop-color="#b07e40"/>
+  <stop offset="100%" stop-color="#5f4223"/>
+</linearGradient>
+<radialGradient id="hot" cx="50%" cy="42%" r="60%">
+  <stop offset="0%" stop-color="#ffe0a0"/><stop offset="55%" stop-color="#e2a24a"/>
+  <stop offset="100%" stop-color="#7a5327"/>
+</radialGradient>
+<radialGradient id="screen" cx="50%" cy="38%" r="75%">
+  <stop offset="0%" stop-color="#ffdf9c"/><stop offset="60%" stop-color="#e0a24c"/>
+  <stop offset="100%" stop-color="#9c6e34"/>
+</radialGradient>
+<linearGradient id="panel" x1="0" y1="0" x2="0" y2="1">
+  <stop offset="0%" stop-color="#2a2015" stop-opacity="0.92"/>
+  <stop offset="100%" stop-color="#140f0a" stop-opacity="0.92"/>
+</linearGradient>
+<radialGradient id="vig" cx="50%" cy="48%" r="62%">
+  <stop offset="60%" stop-color="#000" stop-opacity="0"/>
+  <stop offset="100%" stop-color="#050403" stop-opacity="0.74"/>
+</radialGradient>
+<filter id="glow" x="-120%" y="-120%" width="340%" height="340%"><feGaussianBlur stdDeviation="7"/></filter>
+<filter id="glowbig" x="-150%" y="-150%" width="400%" height="400%"><feGaussianBlur stdDeviation="13"/></filter>
+<filter id="softbig" x="-60%" y="-60%" width="220%" height="220%"><feGaussianBlur stdDeviation="26"/></filter>
+<filter id="grain"><feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="2" stitchTiles="stitch"/>
+  <feColorMatrix type="matrix" values="0 0 0 0 0.9  0 0 0 0 0.7  0 0 0 0 0.4  0 0 0 0.5 0"/></filter>
+</defs>
+<rect width="1200" height="675" fill="url(#ground)"/>
+<ellipse cx="360" cy="300" rx="300" ry="250" fill="url(#coreglow)" filter="url(#softbig)"/>
+<polygon points="277.0,196.0 263.5,219.4 236.5,219.4 223.0,196.0 236.5,172.6 263.5,172.6" fill="none" stroke="#cf9a4e" stroke-opacity="0.28" stroke-width="1"/>
+<circle cx="250.0" cy="196.0" r="3.2" fill="#1a1310" opacity="0.25"/>
+<polygon points="277.0,242.8 263.5,266.1 236.5,266.1 223.0,242.8 236.5,219.4 263.5,219.4" fill="none" stroke="#cf9a4e" stroke-opacity="0.28" stroke-width="1"/>
+<circle cx="250.0" cy="242.7653718043597" r="3.2" fill="#1a1310" opacity="0.25"/>
+<polygon points="277.0,289.5 263.5,312.9 236.5,312.9 223.0,289.5 236.5,266.1 263.5,266.1" fill="url(#cell)" fill-opacity="0.6" stroke="#f0c479" stroke-opacity="0.4" stroke-width="1"/>
+<circle cx="250.0" cy="289.5307436087194" r="3.2" fill="#1a1310" opacity="0.5"/>
+<polygon points="277.0,336.3 263.5,359.7 236.5,359.7 223.0,336.3 236.5,312.9 263.5,312.9" fill="none" stroke="#cf9a4e" stroke-opacity="0.28" stroke-width="1"/>
+<circle cx="250.0" cy="336.29611541307906" r="3.2" fill="#1a1310" opacity="0.25"/>
+<polygon points="317.5,219.4 304.0,242.8 277.0,242.8 263.5,219.4 277.0,196.0 304.0,196.0" fill="url(#cell)" fill-opacity="0.6" stroke="#f0c479" stroke-opacity="0.4" stroke-width="1"/>
+<circle cx="290.5" cy="219.38268590217984" r="3.2" fill="#1a1310" opacity="0.5"/>
+<polygon points="317.5,266.1 304.0,289.5 277.0,289.5 263.5,266.1 277.0,242.8 304.0,242.8" fill="none" stroke="#cf9a4e" stroke-opacity="0.28" stroke-width="1"/>
+<circle cx="290.5" cy="266.14805770653953" r="3.2" fill="#1a1310" opacity="0.25"/>
+<polygon points="317.5,312.9 304.0,336.3 277.0,336.3 263.5,312.9 277.0,289.5 304.0,289.5" fill="none" stroke="#cf9a4e" stroke-opacity="0.28" stroke-width="1"/>
+<circle cx="290.5" cy="312.9134295108992" r="3.2" fill="#1a1310" opacity="0.25"/>
+<polygon points="317.5,359.7 304.0,383.1 277.0,383.1 263.5,359.7 277.0,336.3 304.0,336.3" fill="none" stroke="#cf9a4e" stroke-opacity="0.28" stroke-width="1"/>
+<circle cx="290.5" cy="359.6788013152589" r="3.2" fill="#1a1310" opacity="0.25"/>
+<polygon points="358.0,196.0 344.5,219.4 317.5,219.4 304.0,196.0 317.5,172.6 344.5,172.6" fill="none" stroke="#cf9a4e" stroke-opacity="0.28" stroke-width="1"/>
+<circle cx="331.0" cy="196.0" r="3.2" fill="#1a1310" opacity="0.25"/>
+<ellipse cx="331" cy="243" rx="60" ry="55" fill="url(#heart)" filter="url(#softbig)"/>
+<polygon points="358.0,242.8 344.5,266.1 317.5,266.1 304.0,242.8 317.5,219.4 344.5,219.4" fill="url(#hot)" fill-opacity="0.95" stroke="#f0c479" stroke-opacity="0.7" stroke-width="1.2"/>
+<circle cx="331.0" cy="242.7653718043597" r="3.2" fill="#1a1310" opacity="0.5"/>
+<polygon points="358.0,289.5 344.5,312.9 317.5,312.9 304.0,289.5 317.5,266.1 344.5,266.1" fill="url(#cell)" fill-opacity="0.6" stroke="#f0c479" stroke-opacity="0.4" stroke-width="1"/>
+<circle cx="331.0" cy="289.5307436087194" r="3.2" fill="#1a1310" opacity="0.5"/>
+<polygon points="358.0,336.3 344.5,359.7 317.5,359.7 304.0,336.3 317.5,312.9 344.5,312.9" fill="none" stroke="#cf9a4e" stroke-opacity="0.28" stroke-width="1"/>
+<circle cx="331.0" cy="336.29611541307906" r="3.2" fill="#1a1310" opacity="0.25"/>
+<polygon points="398.5,219.4 385.0,242.8 358.0,242.8 344.5,219.4 358.0,196.0 385.0,196.0" fill="url(#cell)" fill-opacity="0.6" stroke="#f0c479" stroke-opacity="0.4" stroke-width="1"/>
+<circle cx="371.5" cy="219.38268590217984" r="3.2" fill="#1a1310" opacity="0.5"/>
+<polygon points="398.5,266.1 385.0,289.5 358.0,289.5 344.5,266.1 358.0,242.8 385.0,242.8" fill="none" stroke="#cf9a4e" stroke-opacity="0.28" stroke-width="1"/>
+<circle cx="371.5" cy="266.14805770653953" r="3.2" fill="#1a1310" opacity="0.25"/>
+<polygon points="398.5,312.9 385.0,336.3 358.0,336.3 344.5,312.9 358.0,289.5 385.0,289.5" fill="none" stroke="#cf9a4e" stroke-opacity="0.28" stroke-width="1"/>
+<circle cx="371.5" cy="312.9134295108992" r="3.2" fill="#1a1310" opacity="0.25"/>
+<polygon points="398.5,359.7 385.0,383.1 358.0,383.1 344.5,359.7 358.0,336.3 385.0,336.3" fill="url(#cell)" fill-opacity="0.6" stroke="#f0c479" stroke-opacity="0.4" stroke-width="1"/>
+<circle cx="371.5" cy="359.6788013152589" r="3.2" fill="#1a1310" opacity="0.5"/>
+<polygon points="439.0,196.0 425.5,219.4 398.5,219.4 385.0,196.0 398.5,172.6 425.5,172.6" fill="none" stroke="#cf9a4e" stroke-opacity="0.28" stroke-width="1"/>
+<circle cx="412.0" cy="196.0" r="3.2" fill="#1a1310" opacity="0.25"/>
+<polygon points="439.0,242.8 425.5,266.1 398.5,266.1 385.0,242.8 398.5,219.4 425.5,219.4" fill="url(#cell)" fill-opacity="0.6" stroke="#f0c479" stroke-opacity="0.4" stroke-width="1"/>
+<circle cx="412.0" cy="242.7653718043597" r="3.2" fill="#1a1310" opacity="0.5"/>
+<polygon points="439.0,289.5 425.5,312.9 398.5,312.9 385.0,289.5 398.5,266.1 425.5,266.1" fill="none" stroke="#cf9a4e" stroke-opacity="0.28" stroke-width="1"/>
+<circle cx="412.0" cy="289.5307436087194" r="3.2" fill="#1a1310" opacity="0.25"/>
+<polygon points="439.0,336.3 425.5,359.7 398.5,359.7 385.0,336.3 398.5,312.9 425.5,312.9" fill="none" stroke="#cf9a4e" stroke-opacity="0.28" stroke-width="1"/>
+<circle cx="412.0" cy="336.29611541307906" r="3.2" fill="#1a1310" opacity="0.25"/>
+<rect x="244" y="84" width="104" height="40" rx="12" fill="url(#panel)" stroke="#ffdca0" stroke-opacity="0.5" stroke-width="1.4"/>
+<path d="M276,122 l0,14 l16,-14 z" fill="url(#panel)" stroke="#ffdca0" stroke-opacity="0.5" stroke-width="1.4"/>
+<rect x="256" y="96" width="64" height="5" rx="2.5" fill="#e0a24c" opacity="0.5"/>
+<rect x="256" y="108" width="42" height="5" rx="2.5" fill="#e0a24c" opacity="0.5"/>
+<path d="M288,124 L331,243" stroke="#ffe7b0" stroke-width="2" stroke-opacity="0.55" stroke-dasharray="1 6" stroke-linecap="round"/>
+<path d="M371,243 Q600,243 828,196" fill="none" stroke="#d89b4d" stroke-width="2" stroke-opacity="0.5" stroke-linecap="round"/>
+<circle cx="631" cy="228" r="7.8" fill="#ffcf7a" opacity="0.5" filter="url(#glow)"/>
+<circle cx="631" cy="228" r="2.3" fill="#fff3d6"/>
+<path d="M371,243 Q606,243 840,340" fill="none" stroke="#d89b4d" stroke-width="2" stroke-opacity="0.5" stroke-linecap="round"/>
+<circle cx="657" cy="279" r="7.8" fill="#ffcf7a" opacity="0.5" filter="url(#glow)"/>
+<circle cx="657" cy="279" r="2.3" fill="#fff3d6"/>
+<path d="M371,243 Q600,243 828,486" fill="none" stroke="#d89b4d" stroke-width="2" stroke-opacity="0.5" stroke-linecap="round"/>
+<circle cx="658" cy="339" r="7.8" fill="#ffcf7a" opacity="0.5" filter="url(#glow)"/>
+<circle cx="658" cy="339" r="2.3" fill="#fff3d6"/>
+<ellipse cx="880" cy="196" rx="90" ry="80" fill="url(#coreglow)" filter="url(#softbig)"/>
+<rect x="842" y="170" width="76" height="48" rx="6" fill="url(#panel)" stroke="#ffdca0" stroke-opacity="0.55" stroke-width="1.5"/>
+<rect x="852" y="179" width="56" height="30" rx="3" fill="url(#screen)" opacity="0.5"/>
+<path d="M832,226 l96,0 l6,6 l-108,0 z" fill="#7a5327" opacity="0.5"/>
+<ellipse cx="892" cy="340" rx="90" ry="80" fill="url(#coreglow)" filter="url(#softbig)"/>
+<rect x="858" y="310" width="68" height="60" rx="7" fill="url(#panel)" stroke="#ffdca0" stroke-opacity="0.55" stroke-width="1.5"/>
+<polygon points="905.0,338.0 898.5,349.3 885.5,349.3 879.0,338.0 885.5,326.7 898.5,326.7" fill="none" stroke="#ffdca0" stroke-opacity="0.6" stroke-width="1.4"/>
+<line x1="870" y1="362" x2="914" y2="362" stroke="#ffdca0" stroke-opacity="0.18"/>
+<line x1="870" y1="362" x2="914" y2="362" stroke="#ffdca0" stroke-opacity="0.18"/>
+<ellipse cx="880" cy="486" rx="90" ry="80" fill="url(#coreglow)" filter="url(#softbig)"/>
+<circle cx="880" cy="486" r="31" fill="url(#panel)" stroke="#ffdca0" stroke-opacity="0.45" stroke-width="1.5"/>
+<path d="M900,486 Q895,512 870,503" fill="none" stroke="#ffe7b0" stroke-opacity="0.7" stroke-width="2" stroke-linecap="round"/>
+<path d="M876,503 L870,503 L873,508" fill="none" stroke="#ffe7b0" stroke-opacity="0.7" stroke-width="2"/>
+<path d="M860,486 Q865,460 890,469" fill="none" stroke="#ffe7b0" stroke-opacity="0.7" stroke-width="2" stroke-linecap="round"/>
+<path d="M884,469 L890,469 L887,464" fill="none" stroke="#ffe7b0" stroke-opacity="0.7" stroke-width="2"/>
+<g>
+<circle cx="276" cy="266" r="1.0" fill="#f4c983" opacity="0.44" filter="url(#glow)"/>
+<circle cx="268" cy="286" r="2.0" fill="#f4c983" opacity="0.29" filter="url(#glow)"/>
+<circle cx="739" cy="360" r="1.5" fill="#f4c983" opacity="0.37" filter="url(#glow)"/>
+<circle cx="495" cy="208" r="2.1" fill="#f4c983" opacity="0.29" filter="url(#glow)"/>
+<circle cx="750" cy="410" r="0.8" fill="#f4c983" opacity="0.24" filter="url(#glow)"/>
+<circle cx="426" cy="394" r="1.0" fill="#f4c983" opacity="0.37" filter="url(#glow)"/>
+<circle cx="355" cy="382" r="2.0" fill="#f4c983" opacity="0.42" filter="url(#glow)"/>
+<circle cx="244" cy="372" r="1.4" fill="#f4c983" opacity="0.44" filter="url(#glow)"/>
+<circle cx="421" cy="432" r="2.1" fill="#f4c983" opacity="0.44" filter="url(#glow)"/>
+<circle cx="649" cy="396" r="1.6" fill="#f4c983" opacity="0.21" filter="url(#glow)"/>
+<circle cx="751" cy="250" r="0.8" fill="#f4c983" opacity="0.30" filter="url(#glow)"/>
+<circle cx="386" cy="142" r="2.0" fill="#f4c983" opacity="0.19" filter="url(#glow)"/>
+</g>
+<rect width="1200" height="675" fill="url(#vig)"/>
+<rect width="1200" height="675" filter="url(#grain)" opacity="0.05"/>
+<text x="60" y="622" font-family="Mo" font-size="12" letter-spacing="3" fill="#e8b968" fill-opacity="0.55">FIELD NOTES</text>
+<text x="1140" y="622" text-anchor="end" font-family="Mo" font-size="12" letter-spacing="2" fill="#e8b968" fill-opacity="0.38">04 / 06</text>
+</svg>

--- a/beta/public/images/blog/zwei-ebenen-zustand-und-interaktion-light.svg
+++ b/beta/public/images/blog/zwei-ebenen-zustand-und-interaktion-light.svg
@@ -1,0 +1,154 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 675" width="1200" height="675" role="img" aria-label="Konzept (hell): die zwei Ebenen — Speicher der Wahrheit und Chat-Transportschicht, ueber die Agenten koordinieren">
+<defs>
+<style>@font-face{font-family:'Mo';src:url(data:font/woff2;base64,d09GMgABAAAAAA7QAA8AAAAAHEwAAA53AAGzMwAAAAAAAAAAAAAAAAAAAAAAAAAAGigbIBwqBmA/U1RBVEgAgX4RCAqsLKJ4ATYCJAOCTguBKgAEIAVmByAb5RWjolZyVsaI/uKAJ0MfBYTACKR2WmgcqlNCrcK+9m3czlmg3OwcHiCxvo6QZPbncdv/GWET8qJtEERBQImSHOxSEy4D5oysF+n7WcHPCHmA7t3721fDDjigCbQtoDzwkMOAozGBw67/AcA5+31rZVXPhOpPB4AUsDtw9+LTsEznE561Gxt1gDZhjaQWB8+J0MAycHtU/O9aafMPyBVQIQrZs301proS/yazu8nm/l7miHgKQG6riFzVTAFIWJa1FfKUqxCyklRf5gzEKs6tRLzvreZMHlPkAjmAW1N4Du46AgGgyKk1jwChGpTK4D5GrWGMkYPXe9kCO5Ug5nNhDHkEAGAdmFjlMxWUeFcn3hdnxmBrLQA3QZrmkxSAd/QqCCC0mIfYkT5xVvASyK94+l74Tq/FLLxheEgIG/nf/d9CMOZjFN8MeDUvC5TJMbV9Hh6AjXdWVXaoD8xUE/+FsQk5KkEN+IxnJye9uSdiRRhSOCO4ilwNdTXBxgh8/TFrlBEoUEZFy8LKLSaJNWvJnc4urh6+fv4NG9fXAZRRqlUPa+5BY3SaU0pzLwCx4viQUqUOeQCcbOwYK62ceZuJByicVqLMx0aiKBElypSrUKmKnEI1FbVadTS0dPQMGhiZEIiIBAAAnsJV3v0gZ0uQ3wOAFQMcgOL1ivAhjlwQn/HSiTz8pMi5AEJMxSRQY3men2qBU0UMz7qKfQw4lnx6r0ogy88vKcwvKqyWFhULrmfPlRZJpaJ8gbR4S74uT5YnLcovqC7aIi6xLltziwTloi0iSRG3qN4qLdosXnps06qLBJtyRV9NgeBbz0JBhbaQL68Qt2MP/nIEuYLLlsmWZ9QE8shKLuO9ttiCZy/Fz1CY+dyIS0z7uftJACYXe9/Y/iedxprdSK/bUKx8ZeOtFAKsebAp5io0RXQV2J5VenvFaaPzm0zOCUOJu7Am0EPN6KkAoQTTowa89RHWJCGIR7rzTQwHZt748VxHozbUqbvVQRbmUjmn67cgK3mmMunc5v4tfnHrUKiD32TpDJ8HdRnpTLGoIACnTiHpiLvY5wJ+9NbB0chacSv6Lxehu16fy2+ZCD92Y3/olTmCVH7KSEFbvUV4F4nJwtURVqcj5xxlmMBMHpVBOoVkGomkpBI6wLdU4HbEmhqarA39ve9+0juOO9mPJooBQM+h9MK7k1g6QtKazfdEvK41/ZOHjJwR6uhi7jdUwZnDq3lnzEa+JmNzztm1jpGleR+Gh19qljughLpWO3nkE0VeMqfscHpK1zDYUssByGubUJhiTdUnn/TL62V+5hePkNMus4fMMLVm+U3ui2IL1MHVOl9JYHiI4soOpnVLBRKxXDU5xywqC+NHmqC8iUmKM9S9pZt1h7qXwgJHdDnswU3Q8hAimT+AvjmKagdZvZWidvQCZyj5LGQpqe+LtAT/QOWDnTsvwf9zuHzm9f0eCX+WgTHlWgXswYnnFhreUDOYetavvyVd/ndO0Vd48OiEWcj+Sm+hmP25PRp90SADQaHPzzdHf2gVGBiyqjHSVzBJR+l1pQDVWFPU1obCB4Yzj0mdeYh1nqQSrTbJ+jRnXkKFOHZTqrVZWgRcb72sciG+biu29/Ieg3tdfM0ISQqtJf7f/v6w/d+W/YwjGvOf9GEt/aNJ6jeHMuZv3t7uePVMwz2yjiOuI14iqaSDUAotbndJ0pqixMHF/R8xEP2BzpG4cuUNzcW42HRfEiZz7dXwIiKf4I/8dfsQd45FzvZpTG3B6UMxMHH5PH7iL7Qasj3U2swLBlkvLmTsQ9zzrIkqdlFxXDnPY2iaGNRSJoRMhzFK5U/enLOSo5Mf3nvmyeFun1c10qd2JcTwxwNs9snZuX62VuUPVetznGmVJtTA7RmcPCZxXCRoM1pCTeg4PIe8lkaj14LmoE6SnM3YL5+atl8+yybbDixtGm0RSsPxiNkS9lTv5Vqq94Q9FmcyKcasQDZz6CCw2au4tTi6YGoKnb/WzDUnIgNTh48cmVobiACbvQmzn0Xj0S+6MPRk74ofs7CNjtN6UElCM3HvZUvTzstn2YS7x+LtE3syQqk7mmgyRTzKvVyLak/UYzEEG1RtO6+J/91P86+cf7k+Fq4Fe5bJ3HzczRkmy7TK/q1A45tLbsZ3Lb4BkEnIfpt1jECJXF6SSiCEcPJN5s251SNw5KMZw/jQV49nmWzDH/33yy+HnixzwbXHYxDGDsnz5pjs/mMDSnzg/iwzl3dIDmR2qWDt4+OYresnx4NagmeS9svnFghZY5y0MHePRMIUdlXvaW2t3ht2m3zpRh/IPTk3YLNvolGDrcPnI5TPhPZvHFjAMZ/LHfPiBVie20czy+Fd3sf3WlS/qoObB8k5I38xE/smuvV14YA6biP5pE3oLX6GkT5UtubRnFYytR9FPA5nxI32g1ESmnb4R4SBjLBHQyG5Xu/dWlZZ8SGuiW+mNrJ6ZbDRbmYH9RTVb7X35royQlbuccvrPRGnofxpqswjY7b02WqbbWYHM6oFYuotnIffmgK1ZGLP8UvPM8+noy2hEKm0K5cyPeDX0ePc/cdvfSTnuMFI5HHWfWpBxMuBLADJhiX7Ke1W7An6R3se7Og5ZadapuvBzke7e84oWwZ4FW9d2nVxyLPrjUsrQM8cu2MJv31+B6dh+KxQH6usc6l9NGKkN1f67G6L6cX70zliNMGxHYNTve/K/pNWIPqkoorPJnKknWSsRE4ZA1WVnlrNxaWZs8rlSggX1vh3bHz0ecF8OIsVB9d+8JfWkL1e43IyaZB/kijmDQ+2cOEBt86vqUo57VVpnxYshWjUa1vB2LY86kO2lhpb8zUp4W2k2UDFBzguPkAZkO3elPAaB9OqhYJCjv/wpNpX+sPaQQXOhgXzz99a5d9RFav3aavSdmdVyq/RucMDXEt4EHSFoRGvdQVj6/KQj/IPumzLmW37BZhO+hs89U9kcjaSM+z3PoUwHAnYHFEErzYEgih0DbqmNKe84aMn0CMIlBdbWuQO//Up4W1PO4Jhi5VRJXQN3gG3dToUtkz1uT3mtGEHpr93mtL9GiTyNbdBc05V1FejIcNt8Xi0DXqyWHXyuX/4t6ssUb2StSWxI2KkzK5wBNmBRq9dufYrKn3yTnQnhtHT0VXVnfXfrG1CLhkVCNPAZvFLxM6JFz98u77v+j/6R48B6a7tZYayVbSPQojaqNyFPkSglEV4sycfY/VptHqv0F1wvDNQ77Kk+jowDrxZtulvVV0cY98z5XsbcPcHHz7rgjC1S+WgG1WsOYkdyBK2q9wVCo/OAepCauTZsCRyiMLTlpPYttIyGKPoAY4joibPArHTr4oS87c7uCZHrCeiXaUoQLhXTEXuIPbdn3f6W/5of2srjJZf41FXpdzuypRXDbmn47z79xHkDlUTNyfXVHc7MR/96jltL1TigUwa+m8FsOjWIy+s3YpezD1+Ntfn9VhGwyPV0XtqS+ZfRNBY6O/WmmldSjhBmppsrvKqLa23nR0WMUqHWlMXyKjcnrTGEF5NCVsKglXW1YodF57yR3NRRmmr1Ro9bZVA/+5t7OxocHeN9sZ9SYYUwC2sTp8wth0YXnDRrhh2uGqGwiXW2lit09/UqL3HaQ8E3b/DUiQUQP/if+WyyhPQa0+g1xHkFMZah9qS2BkxBi3OAB2wYxl9ICtxZUj443sxd/69t+QwB1YH/Brf3ZHx+INvC66/eMgfWZ4FjI9I7iK6jnniyBM9d/If0l2nvCbeF46cjhw7L+oq3/VYLnfR3Wfczb2Ov76zEeI4Nk2iS5aeaQTzvVv+i/HNst2TkYmM7fKp6RYTbCQ6zrKZngK38UwkoSf9ir2pjEDI1esCfkImhfD/BnaK70Edis9iSjJrxB9i0Ic0C3Ojg6b8e2+ukv/+gzbERAoCGWFh/5HlaarfYOQcxsoo9lKKnxh/rWv7MRjkkunlMUEqLRS6sMmlDm39sl57XnCnxozN8tdcSpPf7PH6GscywvzYfFe/v1djTNo8cZoWy5j83v6oz90+rYOD53DR5Hvcmwxmzsl8J+gAlcTfp7NnUEa4HLU7/HEc0lcGPQptTVgp5DQnLGF1qXD9f9Onpb4+p3k0EHCMjTigTkJPBK3H96Z3nu2aGfLEmlIqY+ilTO7dF9tsCY/mENGz4dIRuspA9tssI1TUOTFmDyTIZDqG6KS3PqRQB3Q6RShQAw+N2d+efC7K7scfRj2hjtMdZ+26hAW1hJzUulv9kZaeUPGGh1DYYzalOvRNTZ16Y8rsocIvbggXsz0Rv7t1QksmyIzL64whOkYjpzfj8nMWn9li8NhsVq/NAHmgek3fFR/Xtxo3W23YUzdm3E6umqIpmnnO75dWluCHixsvNi4tTNiuheHRDXyOpmeF+X9iAzHY8G+0PgrdoxEfPqHsJIoSKH2yByITJ5afEAxij8QJKAC/zGOLnj8n4kRE4vqt4aqernQXQ2mwPuXvP4AYkwtxdVuUXJp8C5SwnNCPJK3ESYldMTVR7dHapDjEmKL+0pQgRmUQ+9l7wS+nwbWPcO3dC1sBYDsAz8lfBsX6jzy9ADvs9Dau/8pT8J4gGoBXL6aPrQ/xXcqahxLJQiLxZ8n3AMSu/gX4RY869bLErYaidWdtu8T+Wx6f/yUBwGfpa1Jws1+l//9l/H+Od4KgAsK891bWuzHDS1cT/rtPkBynmgTxKz1mwvYrsKCIZaknDXagSYmhB/RElm+voAK5XW1dAVRyBT0pgYwALJH51IQDKoiexo4RWwZKwGQFokUSix1pYgE2ghEaKJ5HdhbWm7upfAD4nn6c8CuM0ILI0EUwWjHg6gQQAHDypxqDihBOmp/OEzCiAXk+8IgBXowAKCIGeex2rXiLes+4Xv1mjeg0JWVXg9ZrwAzKjE4jonW3uHGjEB57Tzp5fY1OBoQT) format('woff2');}</style>
+<radialGradient id="ground" cx="46%" cy="48%" r="80%">
+  <stop offset="0%" stop-color="#fdfaf3"/><stop offset="58%" stop-color="#f3ecdb"/><stop offset="100%" stop-color="#e4d9c1"/>
+</radialGradient>
+<radialGradient id="coreglow" cx="50%" cy="50%" r="50%">
+  <stop offset="0%" stop-color="#ffdd93" stop-opacity="0.55"/><stop offset="55%" stop-color="#f2c46a" stop-opacity="0.16"/><stop offset="100%" stop-color="#f0ab4c" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="heart" cx="50%" cy="50%" r="50%">
+  <stop offset="0%" stop-color="#ffe3a0" stop-opacity="0.55"/><stop offset="60%" stop-color="#f0ab4c" stop-opacity="0.12"/><stop offset="100%" stop-color="#f0ab4c" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="halo" cx="50%" cy="50%" r="50%">
+  <stop offset="0%" stop-color="#f6bf5c" stop-opacity="0.7"/><stop offset="100%" stop-color="#f6bf5c" stop-opacity="0"/>
+</radialGradient>
+<linearGradient id="cell" x1="0" y1="0" x2="0" y2="1">
+  <stop offset="0%" stop-color="#f0b957"/><stop offset="55%" stop-color="#d5923c"/><stop offset="100%" stop-color="#b0742c"/>
+</linearGradient>
+<linearGradient id="hot" x1="0" y1="0" x2="0" y2="1">
+  <stop offset="0%" stop-color="#ffe6a6"/><stop offset="50%" stop-color="#f6c065"/><stop offset="100%" stop-color="#dc9d3e"/>
+</linearGradient>
+<linearGradient id="screen" x1="0" y1="0" x2="0" y2="1">
+  <stop offset="0%" stop-color="#ffe7ad"/><stop offset="100%" stop-color="#e6ab52"/>
+</linearGradient>
+<linearGradient id="panel" x1="0" y1="0" x2="0" y2="1">
+  <stop offset="0%" stop-color="#fffaf0"/><stop offset="100%" stop-color="#f4e8d0"/>
+</linearGradient>
+<radialGradient id="vig" cx="50%" cy="46%" r="66%">
+  <stop offset="62%" stop-color="#8a6a34" stop-opacity="0"/><stop offset="100%" stop-color="#8a6a34" stop-opacity="0.16"/>
+</radialGradient>
+<filter id="glow" x="-120%" y="-120%" width="340%" height="340%"><feGaussianBlur stdDeviation="6"/></filter>
+<filter id="glowbig" x="-150%" y="-150%" width="400%" height="400%"><feGaussianBlur stdDeviation="11"/></filter>
+<filter id="softbig" x="-60%" y="-60%" width="220%" height="220%"><feGaussianBlur stdDeviation="24"/></filter>
+<filter id="lift" x="-40%" y="-40%" width="180%" height="200%"><feDropShadow dx="0" dy="6" stdDeviation="11" flood-color="#6e4e24" flood-opacity="0.26"/></filter>
+<filter id="grain"><feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="2" stitchTiles="stitch"/>
+  <feColorMatrix type="matrix" values="0 0 0 0 0.42  0 0 0 0 0.30  0 0 0 0 0.12  0 0 0 0.5 0"/></filter>
+</defs>
+<rect width="1200" height="675" fill="url(#ground)"/>
+<ellipse cx="318" cy="343" rx="210" ry="200" fill="url(#coreglow)" filter="url(#softbig)"/>
+<g filter="url(#lift)"><rect x="168" y="182" width="300" height="322" rx="14" fill="url(#panel)" stroke="#9a6a28" stroke-opacity="0.5" stroke-width="1.4"/></g>
+<polygon points="203.0,208.0 198.5,215.8 189.5,215.8 185.0,208.0 189.5,200.2 198.5,200.2" fill="none" stroke="#9a6a28" stroke-opacity="0.75" stroke-width="1.4"/>
+<line x1="184" y1="228" x2="452" y2="228" stroke="#9a6a28" stroke-opacity="0.18"/>
+<circle cx="194" cy="256" r="3" fill="#9a6a28" opacity="0.55"/>
+<rect x="210" y="251" width="167" height="7" rx="3.5" fill="#b5822f" opacity="0.42"/>
+<circle cx="194" cy="289" r="3" fill="#9a6a28" opacity="0.55"/>
+<rect x="210" y="284" width="188" height="7" rx="3.5" fill="#b5822f" opacity="0.42"/>
+<circle cx="194" cy="322" r="3" fill="#9a6a28" opacity="0.55"/>
+<rect x="210" y="317" width="176" height="7" rx="3.5" fill="#b5822f" opacity="0.42"/>
+<circle cx="194" cy="355" r="3" fill="#9a6a28" opacity="0"/>
+<rect x="210" y="350" width="192" height="7" rx="3.5" fill="#b5822f" opacity="0.00"/>
+<circle cx="194" cy="388" r="3" fill="#9a6a28" opacity="0.55"/>
+<rect x="210" y="383" width="194" height="7" rx="3.5" fill="#b5822f" opacity="0.42"/>
+<circle cx="194" cy="421" r="3" fill="#9a6a28" opacity="0.55"/>
+<rect x="210" y="416" width="155" height="7" rx="3.5" fill="#b5822f" opacity="0.42"/>
+<circle cx="194" cy="454" r="3" fill="#9a6a28" opacity="0.55"/>
+<rect x="210" y="449" width="151" height="7" rx="3.5" fill="#b5822f" opacity="0.42"/>
+<rect x="210" y="349" width="196" height="9" rx="4.5" fill="url(#screen)"/>
+<circle cx="194" cy="355" r="10.4" fill="url(#halo)" filter="url(#glow)"/>
+<circle cx="194" cy="355" r="4.0" fill="#d59433" stroke="#8a5a20" stroke-opacity="0.4" stroke-width="0.6"/>
+<circle cx="192.8" cy="353.8" r="1.6" fill="#fff3d6"/>
+<ellipse cx="854" cy="343" rx="210" ry="200" fill="url(#coreglow)" filter="url(#softbig)"/>
+<g filter="url(#lift)"><rect x="704" y="182" width="300" height="322" rx="14" fill="url(#panel)" stroke="#9a6a28" stroke-opacity="0.5" stroke-width="1.4"/></g>
+<polygon points="739.0,208.0 734.5,215.8 725.5,215.8 721.0,208.0 725.5,200.2 734.5,200.2" fill="none" stroke="#9a6a28" stroke-opacity="0.75" stroke-width="1.4"/>
+<line x1="720" y1="228" x2="988" y2="228" stroke="#9a6a28" stroke-opacity="0.18"/>
+<rect x="726" y="252" width="150" height="30" rx="15" fill="#b5822f" opacity="0.30"/>
+<rect x="866" y="298" width="116" height="30" rx="15" fill="#b5822f" opacity="0.36"/>
+<rect x="726" y="344" width="180" height="30" rx="15" fill="#b5822f" opacity="0.42"/>
+<rect x="850" y="390" width="132" height="30" rx="15" fill="#b5822f" opacity="0.48"/>
+<rect x="726" y="436" width="164" height="30" rx="15" fill="url(#halo)" filter="url(#glow)"/>
+<rect x="726" y="436" width="164" height="30" rx="15" fill="url(#screen)" opacity="1.00"/>
+<path d="M854.0,480 l0,-150" stroke="#9a6a28" stroke-opacity="0.22" stroke-width="1.4" stroke-dasharray="2 7" stroke-linecap="round"/>
+<path d="M360,150 Q360,140 360,182" fill="none" stroke="#9a6a28" stroke-width="1.1" stroke-opacity="0.34" stroke-linecap="round"/>
+<path d="M360,150 Q542,140 724,182" fill="none" stroke="#9a6a28" stroke-width="1.1" stroke-opacity="0.34" stroke-linecap="round"/>
+<path d="M560,118 Q504,124 448,182" fill="none" stroke="#9a6a28" stroke-width="1.1" stroke-opacity="0.34" stroke-linecap="round"/>
+<path d="M560,118 Q642,124 724,182" fill="none" stroke="#9a6a28" stroke-width="1.1" stroke-opacity="0.34" stroke-linecap="round"/>
+<path d="M628,214 Q538,172 448,182" fill="none" stroke="#9a6a28" stroke-width="1.1" stroke-opacity="0.34" stroke-linecap="round"/>
+<path d="M628,214 Q676,172 724,182" fill="none" stroke="#9a6a28" stroke-width="1.1" stroke-opacity="0.34" stroke-linecap="round"/>
+<path d="M760,146 Q604,138 448,182" fill="none" stroke="#9a6a28" stroke-width="1.1" stroke-opacity="0.34" stroke-linecap="round"/>
+<path d="M760,146 Q760,138 760,182" fill="none" stroke="#9a6a28" stroke-width="1.1" stroke-opacity="0.34" stroke-linecap="round"/>
+<path d="M452,232 Q450,181 448,182" fill="none" stroke="#9a6a28" stroke-width="1.1" stroke-opacity="0.34" stroke-linecap="round"/>
+<path d="M452,232 Q588,181 724,182" fill="none" stroke="#9a6a28" stroke-width="1.1" stroke-opacity="0.34" stroke-linecap="round"/>
+<circle cx="392" cy="182" r="5.2" fill="url(#halo)" filter="url(#glow)"/>
+<circle cx="392" cy="182" r="2.0" fill="#d59433" stroke="#8a5a20" stroke-opacity="0.4" stroke-width="0.6"/>
+<circle cx="391.6" cy="181.4" r="0.8" fill="#fff3d6"/>
+<circle cx="801" cy="182" r="5.2" fill="url(#halo)" filter="url(#glow)"/>
+<circle cx="801" cy="182" r="2.0" fill="#d59433" stroke="#8a5a20" stroke-opacity="0.4" stroke-width="0.6"/>
+<circle cx="800.5" cy="181.4" r="0.8" fill="#fff3d6"/>
+<circle cx="260" cy="182" r="5.2" fill="url(#halo)" filter="url(#glow)"/>
+<circle cx="260" cy="182" r="2.0" fill="#d59433" stroke="#8a5a20" stroke-opacity="0.4" stroke-width="0.6"/>
+<circle cx="259.0" cy="181.4" r="0.8" fill="#fff3d6"/>
+<circle cx="963" cy="182" r="5.2" fill="url(#halo)" filter="url(#glow)"/>
+<circle cx="963" cy="182" r="2.0" fill="#d59433" stroke="#8a5a20" stroke-opacity="0.4" stroke-width="0.6"/>
+<circle cx="962.4" cy="181.4" r="0.8" fill="#fff3d6"/>
+<circle cx="311" cy="182" r="5.2" fill="url(#halo)" filter="url(#glow)"/>
+<circle cx="311" cy="182" r="2.0" fill="#d59433" stroke="#8a5a20" stroke-opacity="0.4" stroke-width="0.6"/>
+<circle cx="310.9" cy="181.4" r="0.8" fill="#fff3d6"/>
+<circle cx="928" cy="182" r="5.2" fill="url(#halo)" filter="url(#glow)"/>
+<circle cx="928" cy="182" r="2.0" fill="#d59433" stroke="#8a5a20" stroke-opacity="0.4" stroke-width="0.6"/>
+<circle cx="927.4" cy="181.4" r="0.8" fill="#fff3d6"/>
+<circle cx="313" cy="182" r="5.2" fill="url(#halo)" filter="url(#glow)"/>
+<circle cx="313" cy="182" r="2.0" fill="#d59433" stroke="#8a5a20" stroke-opacity="0.4" stroke-width="0.6"/>
+<circle cx="312.2" cy="181.4" r="0.8" fill="#fff3d6"/>
+<circle cx="885" cy="182" r="5.2" fill="url(#halo)" filter="url(#glow)"/>
+<circle cx="885" cy="182" r="2.0" fill="#d59433" stroke="#8a5a20" stroke-opacity="0.4" stroke-width="0.6"/>
+<circle cx="884.0" cy="181.4" r="0.8" fill="#fff3d6"/>
+<path d="M336,159 Q348,151 360,150" fill="none" stroke="#c78a33" stroke-width="2.0" stroke-opacity="0.55" stroke-linecap="round"/>
+<circle cx="360" cy="150" r="9.2" fill="url(#halo)" filter="url(#glow)"/>
+<ellipse cx="360" cy="150" rx="6.0" ry="2.2" fill="#e7a94c" opacity="0.30" transform="rotate(-59 360 150)"/>
+<ellipse cx="360" cy="150" rx="6.0" ry="2.2" fill="#e7a94c" opacity="0.30" transform="rotate(17 360 150)"/>
+<ellipse cx="360" cy="150" rx="4.0" ry="2.4" fill="#c8862e" stroke="#8a5a20" stroke-opacity="0.5" stroke-width="0.6" transform="rotate(-21 360 150)"/>
+<circle cx="358.8" cy="148.8" r="1.6" fill="#fff3d6"/>
+<path d="M534,114 Q547,113 560,118" fill="none" stroke="#c78a33" stroke-width="2.0" stroke-opacity="0.55" stroke-linecap="round"/>
+<circle cx="560" cy="118" r="9.2" fill="url(#halo)" filter="url(#glow)"/>
+<ellipse cx="560" cy="118" rx="6.0" ry="2.2" fill="#e7a94c" opacity="0.30" transform="rotate(-30 560 118)"/>
+<ellipse cx="560" cy="118" rx="6.0" ry="2.2" fill="#e7a94c" opacity="0.30" transform="rotate(46 560 118)"/>
+<ellipse cx="560" cy="118" rx="4.0" ry="2.4" fill="#c8862e" stroke="#8a5a20" stroke-opacity="0.5" stroke-width="0.6" transform="rotate(8 560 118)"/>
+<circle cx="558.8" cy="116.8" r="1.6" fill="#fff3d6"/>
+<path d="M604,204 Q616,205 628,214" fill="none" stroke="#c78a33" stroke-width="2.0" stroke-opacity="0.55" stroke-linecap="round"/>
+<circle cx="628" cy="214" r="9.2" fill="url(#halo)" filter="url(#glow)"/>
+<ellipse cx="628" cy="214" rx="6.0" ry="2.2" fill="#e7a94c" opacity="0.30" transform="rotate(-16 628 214)"/>
+<ellipse cx="628" cy="214" rx="6.0" ry="2.2" fill="#e7a94c" opacity="0.30" transform="rotate(60 628 214)"/>
+<ellipse cx="628" cy="214" rx="4.0" ry="2.4" fill="#c8862e" stroke="#8a5a20" stroke-opacity="0.5" stroke-width="0.6" transform="rotate(22 628 214)"/>
+<circle cx="626.8" cy="212.8" r="1.6" fill="#fff3d6"/>
+<path d="M734,145 Q747,142 760,146" fill="none" stroke="#c78a33" stroke-width="2.0" stroke-opacity="0.55" stroke-linecap="round"/>
+<circle cx="760" cy="146" r="9.2" fill="url(#halo)" filter="url(#glow)"/>
+<ellipse cx="760" cy="146" rx="6.0" ry="2.2" fill="#e7a94c" opacity="0.30" transform="rotate(-37 760 146)"/>
+<ellipse cx="760" cy="146" rx="6.0" ry="2.2" fill="#e7a94c" opacity="0.30" transform="rotate(39 760 146)"/>
+<ellipse cx="760" cy="146" rx="4.0" ry="2.4" fill="#c8862e" stroke="#8a5a20" stroke-opacity="0.5" stroke-width="0.6" transform="rotate(1 760 146)"/>
+<circle cx="758.8" cy="144.8" r="1.6" fill="#fff3d6"/>
+<path d="M427,226 Q439,225 452,232" fill="none" stroke="#c78a33" stroke-width="2.0" stroke-opacity="0.55" stroke-linecap="round"/>
+<circle cx="452" cy="232" r="9.2" fill="url(#halo)" filter="url(#glow)"/>
+<ellipse cx="452" cy="232" rx="6.0" ry="2.2" fill="#e7a94c" opacity="0.30" transform="rotate(-24 452 232)"/>
+<ellipse cx="452" cy="232" rx="6.0" ry="2.2" fill="#e7a94c" opacity="0.30" transform="rotate(52 452 232)"/>
+<ellipse cx="452" cy="232" rx="4.0" ry="2.4" fill="#c8862e" stroke="#8a5a20" stroke-opacity="0.5" stroke-width="0.6" transform="rotate(14 452 232)"/>
+<circle cx="450.8" cy="230.8" r="1.6" fill="#fff3d6"/>
+<g>
+<circle cx="516" cy="155" r="1.2" fill="#d59a44" opacity="0.47"/>
+<circle cx="721" cy="343" r="1.6" fill="#d59a44" opacity="0.32"/>
+<circle cx="881" cy="296" r="1.8" fill="#d59a44" opacity="0.40"/>
+<circle cx="993" cy="240" r="1.2" fill="#d59a44" opacity="0.24"/>
+<circle cx="872" cy="129" r="1.7" fill="#d59a44" opacity="0.39"/>
+<circle cx="182" cy="382" r="1.0" fill="#d59a44" opacity="0.46"/>
+<circle cx="995" cy="149" r="1.7" fill="#d59a44" opacity="0.42"/>
+<circle cx="250" cy="335" r="1.1" fill="#d59a44" opacity="0.47"/>
+<circle cx="836" cy="462" r="1.1" fill="#d59a44" opacity="0.30"/>
+<circle cx="765" cy="309" r="1.2" fill="#d59a44" opacity="0.47"/>
+<circle cx="1000" cy="184" r="1.1" fill="#d59a44" opacity="0.40"/>
+<circle cx="543" cy="332" r="1.5" fill="#d59a44" opacity="0.32"/>
+</g>
+<rect width="1200" height="675" fill="url(#vig)"/>
+<rect width="1200" height="675" filter="url(#grain)" opacity="0.04"/>
+<text x="60" y="622" font-family="Mo" font-size="12" letter-spacing="3" fill="#9a6a2c" fill-opacity="0.8">FIELD NOTES</text>
+<text x="1140" y="622" text-anchor="end" font-family="Mo" font-size="12" letter-spacing="2" fill="#9a6a2c" fill-opacity="0.55">02 / 06</text>
+</svg>

--- a/beta/public/images/blog/zwei-ebenen-zustand-und-interaktion.svg
+++ b/beta/public/images/blog/zwei-ebenen-zustand-und-interaktion.svg
@@ -1,0 +1,148 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 675" width="1200" height="675" role="img" aria-label="Konzept: die zwei Ebenen — ein Speicher der Wahrheit und eine Chat-Transportschicht, ueber die Agenten koordinieren">
+<defs>
+<style>@font-face{font-family:'Mo';src:url(data:font/woff2;base64,d09GMgABAAAAAA7QAA8AAAAAHEwAAA53AAGzMwAAAAAAAAAAAAAAAAAAAAAAAAAAGigbIBwqBmA/U1RBVEgAgX4RCAqsLKJ4ATYCJAOCTguBKgAEIAVmByAb5RWjolZyVsaI/uKAJ0MfBYTACKR2WmgcqlNCrcK+9m3czlmg3OwcHiCxvo6QZPbncdv/GWET8qJtEERBQImSHOxSEy4D5oysF+n7WcHPCHmA7t3721fDDjigCbQtoDzwkMOAozGBw67/AcA5+31rZVXPhOpPB4AUsDtw9+LTsEznE561Gxt1gDZhjaQWB8+J0MAycHtU/O9aafMPyBVQIQrZs301proS/yazu8nm/l7miHgKQG6riFzVTAFIWJa1FfKUqxCyklRf5gzEKs6tRLzvreZMHlPkAjmAW1N4Du46AgGgyKk1jwChGpTK4D5GrWGMkYPXe9kCO5Ug5nNhDHkEAGAdmFjlMxWUeFcn3hdnxmBrLQA3QZrmkxSAd/QqCCC0mIfYkT5xVvASyK94+l74Tq/FLLxheEgIG/nf/d9CMOZjFN8MeDUvC5TJMbV9Hh6AjXdWVXaoD8xUE/+FsQk5KkEN+IxnJye9uSdiRRhSOCO4ilwNdTXBxgh8/TFrlBEoUEZFy8LKLSaJNWvJnc4urh6+fv4NG9fXAZRRqlUPa+5BY3SaU0pzLwCx4viQUqUOeQCcbOwYK62ceZuJByicVqLMx0aiKBElypSrUKmKnEI1FbVadTS0dPQMGhiZEIiIBAAAnsJV3v0gZ0uQ3wOAFQMcgOL1ivAhjlwQn/HSiTz8pMi5AEJMxSRQY3men2qBU0UMz7qKfQw4lnx6r0ogy88vKcwvKqyWFhULrmfPlRZJpaJ8gbR4S74uT5YnLcovqC7aIi6xLltziwTloi0iSRG3qN4qLdosXnps06qLBJtyRV9NgeBbz0JBhbaQL68Qt2MP/nIEuYLLlsmWZ9QE8shKLuO9ttiCZy/Fz1CY+dyIS0z7uftJACYXe9/Y/iedxprdSK/bUKx8ZeOtFAKsebAp5io0RXQV2J5VenvFaaPzm0zOCUOJu7Am0EPN6KkAoQTTowa89RHWJCGIR7rzTQwHZt748VxHozbUqbvVQRbmUjmn67cgK3mmMunc5v4tfnHrUKiD32TpDJ8HdRnpTLGoIACnTiHpiLvY5wJ+9NbB0chacSv6Lxehu16fy2+ZCD92Y3/olTmCVH7KSEFbvUV4F4nJwtURVqcj5xxlmMBMHpVBOoVkGomkpBI6wLdU4HbEmhqarA39ve9+0juOO9mPJooBQM+h9MK7k1g6QtKazfdEvK41/ZOHjJwR6uhi7jdUwZnDq3lnzEa+JmNzztm1jpGleR+Gh19qljughLpWO3nkE0VeMqfscHpK1zDYUssByGubUJhiTdUnn/TL62V+5hePkNMus4fMMLVm+U3ui2IL1MHVOl9JYHiI4soOpnVLBRKxXDU5xywqC+NHmqC8iUmKM9S9pZt1h7qXwgJHdDnswU3Q8hAimT+AvjmKagdZvZWidvQCZyj5LGQpqe+LtAT/QOWDnTsvwf9zuHzm9f0eCX+WgTHlWgXswYnnFhreUDOYetavvyVd/ndO0Vd48OiEWcj+Sm+hmP25PRp90SADQaHPzzdHf2gVGBiyqjHSVzBJR+l1pQDVWFPU1obCB4Yzj0mdeYh1nqQSrTbJ+jRnXkKFOHZTqrVZWgRcb72sciG+biu29/Ieg3tdfM0ISQqtJf7f/v6w/d+W/YwjGvOf9GEt/aNJ6jeHMuZv3t7uePVMwz2yjiOuI14iqaSDUAotbndJ0pqixMHF/R8xEP2BzpG4cuUNzcW42HRfEiZz7dXwIiKf4I/8dfsQd45FzvZpTG3B6UMxMHH5PH7iL7Qasj3U2swLBlkvLmTsQ9zzrIkqdlFxXDnPY2iaGNRSJoRMhzFK5U/enLOSo5Mf3nvmyeFun1c10qd2JcTwxwNs9snZuX62VuUPVetznGmVJtTA7RmcPCZxXCRoM1pCTeg4PIe8lkaj14LmoE6SnM3YL5+atl8+yybbDixtGm0RSsPxiNkS9lTv5Vqq94Q9FmcyKcasQDZz6CCw2au4tTi6YGoKnb/WzDUnIgNTh48cmVobiACbvQmzn0Xj0S+6MPRk74ofs7CNjtN6UElCM3HvZUvTzstn2YS7x+LtE3syQqk7mmgyRTzKvVyLak/UYzEEG1RtO6+J/91P86+cf7k+Fq4Fe5bJ3HzczRkmy7TK/q1A45tLbsZ3Lb4BkEnIfpt1jECJXF6SSiCEcPJN5s251SNw5KMZw/jQV49nmWzDH/33yy+HnixzwbXHYxDGDsnz5pjs/mMDSnzg/iwzl3dIDmR2qWDt4+OYresnx4NagmeS9svnFghZY5y0MHePRMIUdlXvaW2t3ht2m3zpRh/IPTk3YLNvolGDrcPnI5TPhPZvHFjAMZ/LHfPiBVie20czy+Fd3sf3WlS/qoObB8k5I38xE/smuvV14YA6biP5pE3oLX6GkT5UtubRnFYytR9FPA5nxI32g1ESmnb4R4SBjLBHQyG5Xu/dWlZZ8SGuiW+mNrJ6ZbDRbmYH9RTVb7X35royQlbuccvrPRGnofxpqswjY7b02WqbbWYHM6oFYuotnIffmgK1ZGLP8UvPM8+noy2hEKm0K5cyPeDX0ePc/cdvfSTnuMFI5HHWfWpBxMuBLADJhiX7Ke1W7An6R3se7Og5ZadapuvBzke7e84oWwZ4FW9d2nVxyLPrjUsrQM8cu2MJv31+B6dh+KxQH6usc6l9NGKkN1f67G6L6cX70zliNMGxHYNTve/K/pNWIPqkoorPJnKknWSsRE4ZA1WVnlrNxaWZs8rlSggX1vh3bHz0ecF8OIsVB9d+8JfWkL1e43IyaZB/kijmDQ+2cOEBt86vqUo57VVpnxYshWjUa1vB2LY86kO2lhpb8zUp4W2k2UDFBzguPkAZkO3elPAaB9OqhYJCjv/wpNpX+sPaQQXOhgXzz99a5d9RFav3aavSdmdVyq/RucMDXEt4EHSFoRGvdQVj6/KQj/IPumzLmW37BZhO+hs89U9kcjaSM+z3PoUwHAnYHFEErzYEgih0DbqmNKe84aMn0CMIlBdbWuQO//Up4W1PO4Jhi5VRJXQN3gG3dToUtkz1uT3mtGEHpr93mtL9GiTyNbdBc05V1FejIcNt8Xi0DXqyWHXyuX/4t6ssUb2StSWxI2KkzK5wBNmBRq9dufYrKn3yTnQnhtHT0VXVnfXfrG1CLhkVCNPAZvFLxM6JFz98u77v+j/6R48B6a7tZYayVbSPQojaqNyFPkSglEV4sycfY/VptHqv0F1wvDNQ77Kk+jowDrxZtulvVV0cY98z5XsbcPcHHz7rgjC1S+WgG1WsOYkdyBK2q9wVCo/OAepCauTZsCRyiMLTlpPYttIyGKPoAY4joibPArHTr4oS87c7uCZHrCeiXaUoQLhXTEXuIPbdn3f6W/5of2srjJZf41FXpdzuypRXDbmn47z79xHkDlUTNyfXVHc7MR/96jltL1TigUwa+m8FsOjWIy+s3YpezD1+Ntfn9VhGwyPV0XtqS+ZfRNBY6O/WmmldSjhBmppsrvKqLa23nR0WMUqHWlMXyKjcnrTGEF5NCVsKglXW1YodF57yR3NRRmmr1Ro9bZVA/+5t7OxocHeN9sZ9SYYUwC2sTp8wth0YXnDRrhh2uGqGwiXW2lit09/UqL3HaQ8E3b/DUiQUQP/if+WyyhPQa0+g1xHkFMZah9qS2BkxBi3OAB2wYxl9ICtxZUj443sxd/69t+QwB1YH/Brf3ZHx+INvC66/eMgfWZ4FjI9I7iK6jnniyBM9d/If0l2nvCbeF46cjhw7L+oq3/VYLnfR3Wfczb2Ov76zEeI4Nk2iS5aeaQTzvVv+i/HNst2TkYmM7fKp6RYTbCQ6zrKZngK38UwkoSf9ir2pjEDI1esCfkImhfD/BnaK70Edis9iSjJrxB9i0Ic0C3Ojg6b8e2+ukv/+gzbERAoCGWFh/5HlaarfYOQcxsoo9lKKnxh/rWv7MRjkkunlMUEqLRS6sMmlDm39sl57XnCnxozN8tdcSpPf7PH6GscywvzYfFe/v1djTNo8cZoWy5j83v6oz90+rYOD53DR5Hvcmwxmzsl8J+gAlcTfp7NnUEa4HLU7/HEc0lcGPQptTVgp5DQnLGF1qXD9f9Onpb4+p3k0EHCMjTigTkJPBK3H96Z3nu2aGfLEmlIqY+ilTO7dF9tsCY/mENGz4dIRuspA9tssI1TUOTFmDyTIZDqG6KS3PqRQB3Q6RShQAw+N2d+efC7K7scfRj2hjtMdZ+26hAW1hJzUulv9kZaeUPGGh1DYYzalOvRNTZ16Y8rsocIvbggXsz0Rv7t1QksmyIzL64whOkYjpzfj8nMWn9li8NhsVq/NAHmgek3fFR/Xtxo3W23YUzdm3E6umqIpmnnO75dWluCHixsvNi4tTNiuheHRDXyOpmeF+X9iAzHY8G+0PgrdoxEfPqHsJIoSKH2yByITJ5afEAxij8QJKAC/zGOLnj8n4kRE4vqt4aqernQXQ2mwPuXvP4AYkwtxdVuUXJp8C5SwnNCPJK3ESYldMTVR7dHapDjEmKL+0pQgRmUQ+9l7wS+nwbWPcO3dC1sBYDsAz8lfBsX6jzy9ADvs9Dau/8pT8J4gGoBXL6aPrQ/xXcqahxLJQiLxZ8n3AMSu/gX4RY869bLErYaidWdtu8T+Wx6f/yUBwGfpa1Jws1+l//9l/H+Od4KgAsK891bWuzHDS1cT/rtPkBynmgTxKz1mwvYrsKCIZaknDXagSYmhB/RElm+voAK5XW1dAVRyBT0pgYwALJH51IQDKoiexo4RWwZKwGQFokUSix1pYgE2ghEaKJ5HdhbWm7upfAD4nn6c8CuM0ILI0EUwWjHg6gQQAHDypxqDihBOmp/OEzCiAXk+8IgBXowAKCIGeex2rXiLes+4Xv1mjeg0JWVXg9ZrwAzKjE4jonW3uHGjEB57Tzp5fY1OBoQT) format('woff2');}</style>
+<radialGradient id="ground" cx="50%" cy="50%" r="80%">
+  <stop offset="0%" stop-color="#1c1610"/><stop offset="55%" stop-color="#120e0a"/>
+  <stop offset="100%" stop-color="#090705"/>
+</radialGradient>
+<radialGradient id="coreglow" cx="50%" cy="50%" r="50%">
+  <stop offset="0%" stop-color="#f5bd62" stop-opacity="0.52"/>
+  <stop offset="45%" stop-color="#c8863c" stop-opacity="0.20"/>
+  <stop offset="100%" stop-color="#c8863c" stop-opacity="0"/>
+</radialGradient>
+<radialGradient id="heart" cx="50%" cy="50%" r="50%">
+  <stop offset="0%" stop-color="#ffdf99" stop-opacity="0.55"/>
+  <stop offset="60%" stop-color="#f0ab4c" stop-opacity="0.12"/>
+  <stop offset="100%" stop-color="#f0ab4c" stop-opacity="0"/>
+</radialGradient>
+<linearGradient id="cell" x1="0" y1="0" x2="0" y2="1">
+  <stop offset="0%" stop-color="#eab866"/><stop offset="52%" stop-color="#b07e40"/>
+  <stop offset="100%" stop-color="#5f4223"/>
+</linearGradient>
+<radialGradient id="hot" cx="50%" cy="42%" r="60%">
+  <stop offset="0%" stop-color="#ffe0a0"/><stop offset="55%" stop-color="#e2a24a"/>
+  <stop offset="100%" stop-color="#7a5327"/>
+</radialGradient>
+<radialGradient id="screen" cx="50%" cy="38%" r="75%">
+  <stop offset="0%" stop-color="#ffdf9c"/><stop offset="60%" stop-color="#e0a24c"/>
+  <stop offset="100%" stop-color="#9c6e34"/>
+</radialGradient>
+<linearGradient id="panel" x1="0" y1="0" x2="0" y2="1">
+  <stop offset="0%" stop-color="#2a2015" stop-opacity="0.92"/>
+  <stop offset="100%" stop-color="#140f0a" stop-opacity="0.92"/>
+</linearGradient>
+<radialGradient id="vig" cx="50%" cy="48%" r="62%">
+  <stop offset="60%" stop-color="#000" stop-opacity="0"/>
+  <stop offset="100%" stop-color="#050403" stop-opacity="0.74"/>
+</radialGradient>
+<filter id="glow" x="-120%" y="-120%" width="340%" height="340%"><feGaussianBlur stdDeviation="7"/></filter>
+<filter id="glowbig" x="-150%" y="-150%" width="400%" height="400%"><feGaussianBlur stdDeviation="13"/></filter>
+<filter id="softbig" x="-60%" y="-60%" width="220%" height="220%"><feGaussianBlur stdDeviation="26"/></filter>
+<filter id="grain"><feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="2" stitchTiles="stitch"/>
+  <feColorMatrix type="matrix" values="0 0 0 0 0.9  0 0 0 0 0.7  0 0 0 0 0.4  0 0 0 0.5 0"/></filter>
+</defs>
+<rect width="1200" height="675" fill="url(#ground)"/>
+<ellipse cx="318" cy="343" rx="255" ry="258" fill="url(#coreglow)" filter="url(#softbig)"/>
+<rect x="168" y="182" width="300" height="322" rx="14" fill="url(#panel)" stroke="#ffdca0" stroke-opacity="0.42" stroke-width="1.5"/>
+<polygon points="203.0,208.0 198.5,215.8 189.5,215.8 185.0,208.0 189.5,200.2 198.5,200.2" fill="none" stroke="#ffdca0" stroke-opacity="0.6" stroke-width="1.4"/>
+<line x1="184" y1="228" x2="452" y2="228" stroke="#ffdca0" stroke-opacity="0.14"/>
+<circle cx="194" cy="256" r="3" fill="#e8b968" opacity="0.5"/>
+<rect x="210" y="251" width="167" height="7" rx="3.5" fill="#e0a24c" opacity="0.22"/>
+<circle cx="194" cy="289" r="3" fill="#e8b968" opacity="0.5"/>
+<rect x="210" y="284" width="188" height="7" rx="3.5" fill="#e0a24c" opacity="0.22"/>
+<circle cx="194" cy="322" r="3" fill="#e8b968" opacity="0.5"/>
+<rect x="210" y="317" width="176" height="7" rx="3.5" fill="#e0a24c" opacity="0.22"/>
+<circle cx="194" cy="355" r="3" fill="#e8b968" opacity="0"/>
+<rect x="210" y="350" width="192" height="7" rx="3.5" fill="#e0a24c" opacity="0.22"/>
+<circle cx="194" cy="388" r="3" fill="#e8b968" opacity="0.5"/>
+<rect x="210" y="383" width="194" height="7" rx="3.5" fill="#e0a24c" opacity="0.22"/>
+<circle cx="194" cy="421" r="3" fill="#e8b968" opacity="0.5"/>
+<rect x="210" y="416" width="155" height="7" rx="3.5" fill="#e0a24c" opacity="0.22"/>
+<circle cx="194" cy="454" r="3" fill="#e8b968" opacity="0.5"/>
+<rect x="210" y="449" width="151" height="7" rx="3.5" fill="#e0a24c" opacity="0.22"/>
+<rect x="210" y="349" width="196" height="9" rx="4.5" fill="url(#screen)" opacity="0.9"/>
+<circle cx="194" cy="355" r="14.3" fill="#ffcf7a" opacity="0.5" filter="url(#glow)"/>
+<circle cx="194" cy="355" r="4.2" fill="#fff3d6"/>
+<ellipse cx="854" cy="343" rx="255" ry="258" fill="url(#coreglow)" filter="url(#softbig)"/>
+<rect x="704" y="182" width="300" height="322" rx="14" fill="url(#panel)" stroke="#ffdca0" stroke-opacity="0.42" stroke-width="1.5"/>
+<polygon points="739.0,208.0 734.5,215.8 725.5,215.8 721.0,208.0 725.5,200.2 734.5,200.2" fill="none" stroke="#ffdca0" stroke-opacity="0.6" stroke-width="1.4"/>
+<line x1="720" y1="228" x2="988" y2="228" stroke="#ffdca0" stroke-opacity="0.14"/>
+<rect x="726" y="252" width="150" height="30" rx="15" fill="#e0a24c" opacity="0.20"/>
+<rect x="866" y="298" width="116" height="30" rx="15" fill="#e0a24c" opacity="0.25"/>
+<rect x="726" y="344" width="180" height="30" rx="15" fill="#e0a24c" opacity="0.30"/>
+<rect x="850" y="390" width="132" height="30" rx="15" fill="#e0a24c" opacity="0.35"/>
+<rect x="726" y="436" width="164" height="30" rx="15" fill="#ffcf7a" opacity="0.5" filter="url(#glow)"/>
+<rect x="726" y="436" width="164" height="30" rx="15" fill="url(#screen)" opacity="0.92"/>
+<path d="M854.0,480 l0,-150" stroke="#ffdca0" stroke-opacity="0.18" stroke-width="1.4" stroke-dasharray="2 7" stroke-linecap="round"/>
+<path d="M360,150 Q360,140 360,182" fill="none" stroke="#ffd98f" stroke-width="1.1" stroke-opacity="0.30" stroke-linecap="round"/>
+<path d="M360,150 Q542,140 724,182" fill="none" stroke="#ffd98f" stroke-width="1.1" stroke-opacity="0.30" stroke-linecap="round"/>
+<path d="M560,118 Q504,124 448,182" fill="none" stroke="#ffd98f" stroke-width="1.1" stroke-opacity="0.30" stroke-linecap="round"/>
+<path d="M560,118 Q642,124 724,182" fill="none" stroke="#ffd98f" stroke-width="1.1" stroke-opacity="0.30" stroke-linecap="round"/>
+<path d="M628,214 Q538,172 448,182" fill="none" stroke="#ffd98f" stroke-width="1.1" stroke-opacity="0.30" stroke-linecap="round"/>
+<path d="M628,214 Q676,172 724,182" fill="none" stroke="#ffd98f" stroke-width="1.1" stroke-opacity="0.30" stroke-linecap="round"/>
+<path d="M760,146 Q604,138 448,182" fill="none" stroke="#ffd98f" stroke-width="1.1" stroke-opacity="0.30" stroke-linecap="round"/>
+<path d="M760,146 Q760,138 760,182" fill="none" stroke="#ffd98f" stroke-width="1.1" stroke-opacity="0.30" stroke-linecap="round"/>
+<path d="M452,232 Q450,181 448,182" fill="none" stroke="#ffd98f" stroke-width="1.1" stroke-opacity="0.30" stroke-linecap="round"/>
+<path d="M452,232 Q588,181 724,182" fill="none" stroke="#ffd98f" stroke-width="1.1" stroke-opacity="0.30" stroke-linecap="round"/>
+<circle cx="392" cy="182" r="7.5" fill="#ffcf7a" opacity="0.5" filter="url(#glow)"/>
+<circle cx="392" cy="182" r="2.2" fill="#fff3d6"/>
+<circle cx="801" cy="182" r="7.5" fill="#ffcf7a" opacity="0.5" filter="url(#glow)"/>
+<circle cx="801" cy="182" r="2.2" fill="#fff3d6"/>
+<circle cx="260" cy="182" r="7.5" fill="#ffcf7a" opacity="0.5" filter="url(#glow)"/>
+<circle cx="260" cy="182" r="2.2" fill="#fff3d6"/>
+<circle cx="963" cy="182" r="7.5" fill="#ffcf7a" opacity="0.5" filter="url(#glow)"/>
+<circle cx="963" cy="182" r="2.2" fill="#fff3d6"/>
+<circle cx="311" cy="182" r="7.5" fill="#ffcf7a" opacity="0.5" filter="url(#glow)"/>
+<circle cx="311" cy="182" r="2.2" fill="#fff3d6"/>
+<circle cx="928" cy="182" r="7.5" fill="#ffcf7a" opacity="0.5" filter="url(#glow)"/>
+<circle cx="928" cy="182" r="2.2" fill="#fff3d6"/>
+<circle cx="313" cy="182" r="7.5" fill="#ffcf7a" opacity="0.5" filter="url(#glow)"/>
+<circle cx="313" cy="182" r="2.2" fill="#fff3d6"/>
+<circle cx="885" cy="182" r="7.5" fill="#ffcf7a" opacity="0.5" filter="url(#glow)"/>
+<circle cx="885" cy="182" r="2.2" fill="#fff3d6"/>
+<path d="M336,159 Q348,151 360,150" fill="none" stroke="#ffd98f" stroke-width="2.0" stroke-opacity="0.40" stroke-linecap="round"/>
+<circle cx="360" cy="150" r="9.2" fill="#ffcf7a" opacity="0.50" filter="url(#glow)"/>
+<ellipse cx="360" cy="150" rx="6.0" ry="2.2" fill="#ffe9c4" opacity="0.18" transform="rotate(-59 360 150)"/>
+<ellipse cx="360" cy="150" rx="6.0" ry="2.2" fill="#ffe9c4" opacity="0.18" transform="rotate(17 360 150)"/>
+<ellipse cx="360" cy="150" rx="4.0" ry="2.4" fill="#fff3d6" transform="rotate(-21 360 150)"/>
+<path d="M534,114 Q547,113 560,118" fill="none" stroke="#ffd98f" stroke-width="2.0" stroke-opacity="0.40" stroke-linecap="round"/>
+<circle cx="560" cy="118" r="9.2" fill="#ffcf7a" opacity="0.50" filter="url(#glow)"/>
+<ellipse cx="560" cy="118" rx="6.0" ry="2.2" fill="#ffe9c4" opacity="0.18" transform="rotate(-30 560 118)"/>
+<ellipse cx="560" cy="118" rx="6.0" ry="2.2" fill="#ffe9c4" opacity="0.18" transform="rotate(46 560 118)"/>
+<ellipse cx="560" cy="118" rx="4.0" ry="2.4" fill="#fff3d6" transform="rotate(8 560 118)"/>
+<path d="M604,204 Q616,205 628,214" fill="none" stroke="#ffd98f" stroke-width="2.0" stroke-opacity="0.40" stroke-linecap="round"/>
+<circle cx="628" cy="214" r="9.2" fill="#ffcf7a" opacity="0.50" filter="url(#glow)"/>
+<ellipse cx="628" cy="214" rx="6.0" ry="2.2" fill="#ffe9c4" opacity="0.18" transform="rotate(-16 628 214)"/>
+<ellipse cx="628" cy="214" rx="6.0" ry="2.2" fill="#ffe9c4" opacity="0.18" transform="rotate(60 628 214)"/>
+<ellipse cx="628" cy="214" rx="4.0" ry="2.4" fill="#fff3d6" transform="rotate(22 628 214)"/>
+<path d="M734,145 Q747,142 760,146" fill="none" stroke="#ffd98f" stroke-width="2.0" stroke-opacity="0.40" stroke-linecap="round"/>
+<circle cx="760" cy="146" r="9.2" fill="#ffcf7a" opacity="0.50" filter="url(#glow)"/>
+<ellipse cx="760" cy="146" rx="6.0" ry="2.2" fill="#ffe9c4" opacity="0.18" transform="rotate(-37 760 146)"/>
+<ellipse cx="760" cy="146" rx="6.0" ry="2.2" fill="#ffe9c4" opacity="0.18" transform="rotate(39 760 146)"/>
+<ellipse cx="760" cy="146" rx="4.0" ry="2.4" fill="#fff3d6" transform="rotate(1 760 146)"/>
+<path d="M427,226 Q439,225 452,232" fill="none" stroke="#ffd98f" stroke-width="2.0" stroke-opacity="0.40" stroke-linecap="round"/>
+<circle cx="452" cy="232" r="9.2" fill="#ffcf7a" opacity="0.50" filter="url(#glow)"/>
+<ellipse cx="452" cy="232" rx="6.0" ry="2.2" fill="#ffe9c4" opacity="0.18" transform="rotate(-24 452 232)"/>
+<ellipse cx="452" cy="232" rx="6.0" ry="2.2" fill="#ffe9c4" opacity="0.18" transform="rotate(52 452 232)"/>
+<ellipse cx="452" cy="232" rx="4.0" ry="2.4" fill="#fff3d6" transform="rotate(14 452 232)"/>
+<g>
+<circle cx="516" cy="155" r="1.0" fill="#f4c983" opacity="0.47" filter="url(#glow)"/>
+<circle cx="721" cy="343" r="1.5" fill="#f4c983" opacity="0.28" filter="url(#glow)"/>
+<circle cx="881" cy="296" r="1.8" fill="#f4c983" opacity="0.38" filter="url(#glow)"/>
+<circle cx="993" cy="240" r="1.0" fill="#f4c983" opacity="0.20" filter="url(#glow)"/>
+<circle cx="872" cy="129" r="1.7" fill="#f4c983" opacity="0.37" filter="url(#glow)"/>
+<circle cx="182" cy="382" r="0.8" fill="#f4c983" opacity="0.45" filter="url(#glow)"/>
+<circle cx="995" cy="149" r="1.7" fill="#f4c983" opacity="0.41" filter="url(#glow)"/>
+<circle cx="250" cy="335" r="1.0" fill="#f4c983" opacity="0.47" filter="url(#glow)"/>
+<circle cx="836" cy="462" r="0.9" fill="#f4c983" opacity="0.26" filter="url(#glow)"/>
+<circle cx="765" cy="309" r="1.0" fill="#f4c983" opacity="0.46" filter="url(#glow)"/>
+<circle cx="1000" cy="184" r="1.0" fill="#f4c983" opacity="0.38" filter="url(#glow)"/>
+<circle cx="543" cy="332" r="1.4" fill="#f4c983" opacity="0.29" filter="url(#glow)"/>
+<circle cx="143" cy="115" r="1.4" fill="#f4c983" opacity="0.40" filter="url(#glow)"/>
+<circle cx="563" cy="365" r="1.5" fill="#f4c983" opacity="0.46" filter="url(#glow)"/>
+</g>
+<rect width="1200" height="675" fill="url(#vig)"/>
+<rect width="1200" height="675" filter="url(#grain)" opacity="0.05"/>
+<text x="60" y="622" font-family="Mo" font-size="12" letter-spacing="3" fill="#e8b968" fill-opacity="0.55">FIELD NOTES</text>
+<text x="1140" y="622" text-anchor="end" font-family="Mo" font-size="12" letter-spacing="2" fill="#e8b968" fill-opacity="0.38">02 / 06</text>
+</svg>

--- a/beta/src/components/BlogCard.astro
+++ b/beta/src/components/BlogCard.astro
@@ -7,15 +7,16 @@ interface Props {
   readingTime?: string;
   slug: string;
   image?: string;
+  draft?: boolean;
 }
 
 import BlogCover from './BlogCover.astro';
 
-const { title, excerpt, category, order, readingTime, slug, image } = Astro.props;
+const { title, excerpt, category, order, readingTime, slug, image, draft } = Astro.props;
 const partLabel = `Teil ${String(order).padStart(2, '0')}`;
 ---
 
-<article class="a-blog-card">
+<article class="a-blog-card" data-draft={draft ? '' : undefined}>
   {image && (
     <a class="a-blog-card__cover" href={`/blog/${slug}`} aria-hidden="true" tabindex="-1">
       <BlogCover image={image} />
@@ -24,6 +25,7 @@ const partLabel = `Teil ${String(order).padStart(2, '0')}`;
   <div class="a-blog-card__meta">
     <span class="a-blog-card__part">{partLabel}</span>
     <span class="a-blog-card__category">{category}</span>
+    {draft && <span class="a-blog-card__draft">Vorschau</span>}
   </div>
   <h3 class="a-blog-card__title">
     <a href={`/blog/${slug}`}>{title}</a>
@@ -80,6 +82,15 @@ const partLabel = `Teil ${String(order).padStart(2, '0')}`;
 
   .a-blog-card__category {
     color: var(--ink-soft);
+  }
+
+  .a-blog-card__draft {
+    margin-left: auto;
+    padding: 2px 8px;
+    border: 1px solid var(--accent);
+    border-radius: var(--radius-full);
+    color: var(--accent);
+    letter-spacing: var(--ls-wide);
   }
 
   .a-blog-card__title {

--- a/beta/src/components/BlogCard.astro
+++ b/beta/src/components/BlogCard.astro
@@ -6,13 +6,21 @@ interface Props {
   order: number;
   readingTime?: string;
   slug: string;
+  image?: string;
 }
 
-const { title, excerpt, category, order, readingTime, slug } = Astro.props;
+import BlogCover from './BlogCover.astro';
+
+const { title, excerpt, category, order, readingTime, slug, image } = Astro.props;
 const partLabel = `Teil ${String(order).padStart(2, '0')}`;
 ---
 
 <article class="a-blog-card">
+  {image && (
+    <a class="a-blog-card__cover" href={`/blog/${slug}`} aria-hidden="true" tabindex="-1">
+      <BlogCover image={image} />
+    </a>
+  )}
   <div class="a-blog-card__meta">
     <span class="a-blog-card__part">{partLabel}</span>
     <span class="a-blog-card__category">{category}</span>
@@ -46,6 +54,14 @@ const partLabel = `Teil ${String(order).padStart(2, '0')}`;
   .a-blog-card:hover {
     transform: translateY(-4px);
     border-color: var(--accent);
+  }
+
+  /* Full-bleed cover: pull to the card's padding-box edges, round the top corners. */
+  .a-blog-card__cover {
+    display: block;
+    margin: calc(-1 * var(--space-xl)) calc(-1 * var(--space-xl)) 0;
+    border-radius: var(--radius-sm) var(--radius-sm) 0 0;
+    overflow: hidden;
   }
 
   .a-blog-card__meta {

--- a/beta/src/components/BlogCard.astro
+++ b/beta/src/components/BlogCard.astro
@@ -1,0 +1,106 @@
+---
+interface Props {
+  title: string;
+  excerpt: string;
+  category: string;
+  order: number;
+  readingTime?: string;
+  slug: string;
+}
+
+const { title, excerpt, category, order, readingTime, slug } = Astro.props;
+const partLabel = `Teil ${String(order).padStart(2, '0')}`;
+---
+
+<article class="a-blog-card">
+  <div class="a-blog-card__meta">
+    <span class="a-blog-card__part">{partLabel}</span>
+    <span class="a-blog-card__category">{category}</span>
+  </div>
+  <h3 class="a-blog-card__title">
+    <a href={`/blog/${slug}`}>{title}</a>
+  </h3>
+  <p class="a-blog-card__excerpt">{excerpt}</p>
+  <div class="a-blog-card__footer">
+    <a href={`/blog/${slug}`} class="bf-cta">
+      Lesen <span aria-hidden="true">→</span>
+    </a>
+    {readingTime && <span class="a-blog-card__time">{readingTime}</span>}
+  </div>
+</article>
+
+<style>
+  .a-blog-card {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+    padding: var(--space-xl);
+    background: var(--paper);
+    border: 1px solid var(--rule);
+    border-radius: var(--radius-sm);
+    border-left: 4px solid var(--accent);
+    min-height: 100%;
+    transition: transform var(--duration-fast) var(--easing-default), border-color var(--duration-fast) var(--easing-default);
+  }
+
+  .a-blog-card:hover {
+    transform: translateY(-4px);
+    border-color: var(--accent);
+  }
+
+  .a-blog-card__meta {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    text-transform: uppercase;
+    letter-spacing: var(--ls-wider);
+  }
+
+  .a-blog-card__part {
+    color: var(--accent);
+  }
+
+  .a-blog-card__category {
+    color: var(--ink-soft);
+  }
+
+  .a-blog-card__title {
+    font-family: var(--font-display);
+    font-size: var(--text-xl);
+    line-height: var(--lh-snug);
+    margin: 0;
+    color: var(--ink);
+  }
+
+  .a-blog-card__title a {
+    color: inherit;
+    text-decoration: none;
+  }
+
+  .a-blog-card__title a:hover {
+    color: var(--accent);
+  }
+
+  .a-blog-card__excerpt {
+    color: var(--ink-soft);
+    margin: 0;
+    flex-grow: 1;
+    line-height: var(--lh-body);
+  }
+
+  .a-blog-card__footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-md);
+    margin-top: var(--space-sm);
+  }
+
+  .a-blog-card__time {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--ink-soft);
+  }
+</style>

--- a/beta/src/components/BlogCover.astro
+++ b/beta/src/components/BlogCover.astro
@@ -1,0 +1,40 @@
+---
+/**
+ * Theme-aware teaser cover. Renders the dark scene by default under
+ * [data-theme="dark"] and the warm "-light" variant otherwise. Uses
+ * background-image so the browser only fetches the theme-correct SVG.
+ * The light path is derived from the dark one: <slug>.svg -> <slug>-light.svg.
+ */
+interface Props {
+  image: string;
+  class?: string;
+}
+
+const { image, class: className } = Astro.props;
+const lightImage = image.replace(/\.svg$/, '-light.svg');
+---
+
+<div
+  class:list={['a-cover', className]}
+  aria-hidden="true"
+  style={`--cover-dark:url('${image}');--cover-light:url('${lightImage}')`}
+>
+</div>
+
+<style>
+  .a-cover {
+    display: block;
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    background-color: #f3ecdb;
+    background-image: var(--cover-light);
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
+  }
+
+  :global([data-theme='dark']) .a-cover {
+    background-color: #0e0b08;
+    background-image: var(--cover-dark);
+  }
+</style>

--- a/beta/src/components/BlogList.astro
+++ b/beta/src/components/BlogList.astro
@@ -1,27 +1,30 @@
 ---
 import BlogCard from './BlogCard.astro';
-import { getBlogPosts } from '../lib/blog';
+import { getAllBlogPosts } from '../lib/blog';
 
-const posts = await getBlogPosts();
+// Render every post so the magic preview link can reveal drafts client-side.
+// Draft cards are hidden by default (CSS) unless [data-preview="on"] is set.
+const posts = await getAllBlogPosts();
+const publishedCount = posts.filter(p => p.data.published).length;
 ---
 
 <section class="a-blog-list">
   <div class="bf-container">
-    {posts.length > 0 ? (
-      <div class="a-blog-list__grid">
-        {posts.map(post => (
-          <BlogCard
-            title={post.data.title}
-            excerpt={post.data.excerpt}
-            category={post.data.category}
-            order={post.data.order}
-            readingTime={post.data.readingTime}
-            slug={post.id}
-            image={post.data.image}
-          />
-        ))}
-      </div>
-    ) : (
+    <div class="a-blog-list__grid">
+      {posts.map(post => (
+        <BlogCard
+          title={post.data.title}
+          excerpt={post.data.excerpt}
+          category={post.data.category}
+          order={post.data.order}
+          readingTime={post.data.readingTime}
+          slug={post.id}
+          image={post.data.image}
+          draft={!post.data.published}
+        />
+      ))}
+    </div>
+    {publishedCount === 0 && (
       <p class="a-blog-list__empty">Die Artikelserie erscheint in Kürze.</p>
     )}
   </div>
@@ -43,6 +46,19 @@ const posts = await getBlogPosts();
     text-align: center;
     color: var(--ink-soft);
     padding: 3rem 0;
+  }
+
+  /* Draft cards are hidden until the magic preview key unlocks the session. */
+  :global(.a-blog-card[data-draft]) {
+    display: none;
+  }
+
+  :global([data-preview='on'] .a-blog-card[data-draft]) {
+    display: flex;
+  }
+
+  :global([data-preview='on']) .a-blog-list__empty {
+    display: none;
   }
 
   @media (max-width: 768px) {

--- a/beta/src/components/BlogList.astro
+++ b/beta/src/components/BlogList.astro
@@ -1,9 +1,8 @@
 ---
-import { getCollection } from 'astro:content';
 import BlogCard from './BlogCard.astro';
+import { getBlogPosts } from '../lib/blog';
 
-const posts = (await getCollection('blog', ({ data }) => data.published))
-  .sort((a, b) => a.data.order - b.data.order);
+const posts = await getBlogPosts();
 ---
 
 <section class="a-blog-list">
@@ -18,6 +17,7 @@ const posts = (await getCollection('blog', ({ data }) => data.published))
             order={post.data.order}
             readingTime={post.data.readingTime}
             slug={post.id}
+            image={post.data.image}
           />
         ))}
       </div>

--- a/beta/src/components/BlogList.astro
+++ b/beta/src/components/BlogList.astro
@@ -1,0 +1,53 @@
+---
+import { getCollection } from 'astro:content';
+import BlogCard from './BlogCard.astro';
+
+const posts = (await getCollection('blog', ({ data }) => data.published))
+  .sort((a, b) => a.data.order - b.data.order);
+---
+
+<section class="a-blog-list">
+  <div class="bf-container">
+    {posts.length > 0 ? (
+      <div class="a-blog-list__grid">
+        {posts.map(post => (
+          <BlogCard
+            title={post.data.title}
+            excerpt={post.data.excerpt}
+            category={post.data.category}
+            order={post.data.order}
+            readingTime={post.data.readingTime}
+            slug={post.id}
+          />
+        ))}
+      </div>
+    ) : (
+      <p class="a-blog-list__empty">Die Artikelserie erscheint in Kürze.</p>
+    )}
+  </div>
+</section>
+
+<style>
+  .a-blog-list {
+    padding: var(--space-xl) 0 var(--space-4xl);
+    background: transparent;
+  }
+
+  .a-blog-list__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 2rem;
+  }
+
+  .a-blog-list__empty {
+    text-align: center;
+    color: var(--ink-soft);
+    padding: 3rem 0;
+  }
+
+  @media (max-width: 768px) {
+    .a-blog-list__grid {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/beta/src/components/FieldNotesTeaser.astro
+++ b/beta/src/components/FieldNotesTeaser.astro
@@ -1,0 +1,156 @@
+---
+import { getCollection } from 'astro:content';
+
+interface Props {
+  lang?: 'DE' | 'EN';
+}
+
+const { lang = 'DE' } = Astro.props;
+
+// Only surface the teaser once at least one article is live — never link to an
+// empty blog. Mirrors the gating on the nav link.
+const posts = (await getCollection('blog', ({ data }) => data.published))
+  .sort((a, b) => a.data.order - b.data.order);
+const hasPosts = posts.length > 0;
+const lead = posts[0];
+
+const copy = lang === 'DE'
+  ? {
+      kicker: 'Field Notes · KI-Serie',
+      heading: 'Die romantische Vorstellung stimmt — hier ist der Schatz.',
+      body: 'Wir haben für ein deutsches Legal-Tech-Unternehmen ein komplettes KI-Agenten-Betriebssystem gebaut: autonome Bots, die Pull-Requests öffnen, ein Skill-Marktplatz für Firmenwissen, ein Cockpit, das den Tag plant. Kein Proof-of-Concept — Produktion. Wir schreiben es auf.',
+      cta: 'Zur Artikelserie',
+      readMore: 'Zum Auftakt',
+    }
+  : {
+      kicker: 'Field Notes · AI series',
+      heading: 'The romantic notion is true — here is the treasure.',
+      body: 'We built a full AI-agent operating system for a German legal-tech company: autonomous bots that open pull requests, a skill marketplace for institutional knowledge, a cockpit that plans the day. Not a proof of concept — production. We write it up (in German).',
+      cta: 'Read the series',
+      readMore: 'Start here',
+    };
+---
+
+{hasPosts && (
+  <section class="fnt bf-section">
+    <div class="bf-container">
+      <div class="fnt__card">
+        <div class="fnt__body">
+          <span class="fnt__kicker">{copy.kicker}</span>
+          <h2 class="fnt__heading">{copy.heading}</h2>
+          <p class="fnt__text">{copy.body}</p>
+          <a href="/blog" class="fnt__cta">{copy.cta} <span aria-hidden="true">→</span></a>
+        </div>
+        {lead && (
+          <a class="fnt__lead" href={`/blog/${lead.id}`}>
+            <span class="fnt__lead-part">Teil {String(lead.data.order).padStart(2, '0')} · {copy.readMore}</span>
+            <span class="fnt__lead-title">{lead.data.title}</span>
+            <span class="fnt__lead-excerpt">{lead.data.excerpt}</span>
+          </a>
+        )}
+      </div>
+    </div>
+  </section>
+)}
+
+<style>
+  .fnt {
+    padding: var(--space-3xl) 0;
+    background: var(--bg);
+  }
+
+  .fnt__card {
+    display: grid;
+    grid-template-columns: 1.1fr 1fr;
+    gap: var(--space-3xl);
+    align-items: center;
+    padding: var(--space-2xl);
+    border: 1px solid var(--rule);
+    border-left: 4px solid var(--accent);
+    border-radius: var(--radius-sm);
+    background: var(--paper);
+  }
+
+  .fnt__kicker {
+    display: inline-block;
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    text-transform: uppercase;
+    letter-spacing: var(--ls-widest);
+    color: var(--accent);
+    margin-bottom: var(--space-md);
+  }
+
+  .fnt__heading {
+    font-family: var(--font-display);
+    font-size: var(--text-3xl);
+    line-height: var(--lh-snug);
+    margin: 0 0 var(--space-md);
+    color: var(--ink);
+  }
+
+  .fnt__text {
+    color: var(--ink-soft);
+    line-height: var(--lh-body);
+    margin: 0 0 var(--space-lg);
+  }
+
+  .fnt__cta {
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    letter-spacing: var(--ls-wide);
+    text-transform: uppercase;
+    color: var(--accent);
+    text-decoration: none;
+  }
+
+  .fnt__cta:hover { opacity: 0.7; }
+
+  .fnt__lead {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+    padding: var(--space-xl);
+    border: 1px solid var(--rule);
+    border-radius: var(--radius-sm);
+    background: var(--bg);
+    text-decoration: none;
+    transition: border-color var(--duration-fast) var(--easing-default), transform var(--duration-fast) var(--easing-default);
+  }
+
+  .fnt__lead:hover {
+    border-color: var(--accent);
+    transform: translateY(-3px);
+  }
+
+  .fnt__lead-part {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    text-transform: uppercase;
+    letter-spacing: var(--ls-wider);
+    color: var(--accent);
+  }
+
+  .fnt__lead-title {
+    font-family: var(--font-display);
+    font-size: var(--text-lg);
+    color: var(--ink);
+    line-height: var(--lh-snug);
+  }
+
+  .fnt__lead-excerpt {
+    font-size: var(--text-sm);
+    color: var(--ink-soft);
+    line-height: var(--lh-body);
+  }
+
+  @media (max-width: 768px) {
+    .fnt { padding: var(--space-2xl) 0; }
+    .fnt__card {
+      grid-template-columns: 1fr;
+      gap: var(--space-xl);
+      padding: var(--space-xl);
+    }
+    .fnt__heading { font-size: var(--text-2xl); }
+  }
+</style>

--- a/beta/src/components/FieldNotesTeaser.astro
+++ b/beta/src/components/FieldNotesTeaser.astro
@@ -1,5 +1,6 @@
 ---
-import { getCollection } from 'astro:content';
+import BlogCover from './BlogCover.astro';
+import { getBlogPosts } from '../lib/blog';
 
 interface Props {
   lang?: 'DE' | 'EN';
@@ -9,8 +10,7 @@ const { lang = 'DE' } = Astro.props;
 
 // Only surface the teaser once at least one article is live — never link to an
 // empty blog. Mirrors the gating on the nav link.
-const posts = (await getCollection('blog', ({ data }) => data.published))
-  .sort((a, b) => a.data.order - b.data.order);
+const posts = await getBlogPosts();
 const hasPosts = posts.length > 0;
 const lead = posts[0];
 
@@ -43,6 +43,11 @@ const copy = lang === 'DE'
         </div>
         {lead && (
           <a class="fnt__lead" href={`/blog/${lead.id}`}>
+            {lead.data.image && (
+              <span class="fnt__lead-cover">
+                <BlogCover image={lead.data.image} />
+              </span>
+            )}
             <span class="fnt__lead-part">Teil {String(lead.data.order).padStart(2, '0')} · {copy.readMore}</span>
             <span class="fnt__lead-title">{lead.data.title}</span>
             <span class="fnt__lead-excerpt">{lead.data.excerpt}</span>
@@ -121,6 +126,13 @@ const copy = lang === 'DE'
   .fnt__lead:hover {
     border-color: var(--accent);
     transform: translateY(-3px);
+  }
+
+  .fnt__lead-cover {
+    display: block;
+    margin: calc(-1 * var(--space-xl)) calc(-1 * var(--space-xl)) var(--space-xs);
+    border-radius: var(--radius-sm) var(--radius-sm) 0 0;
+    overflow: hidden;
   }
 
   .fnt__lead-part {

--- a/beta/src/components/Layout.astro
+++ b/beta/src/components/Layout.astro
@@ -1,5 +1,6 @@
 ---
 import '../styles/design-system.css';
+import { PREVIEW_KEY } from '../lib/blog';
 
 const SITE_URL = 'https://bumbleflies.de';
 const DEFAULT_DESCRIPTION = 'bumbleflies — Facilitation, AI Consulting, App Development. From Conversation to Code.';
@@ -119,6 +120,22 @@ const jsonLd = JSON.stringify({
       } else {
         document.documentElement.removeAttribute('data-theme');
       }
+    </script>
+
+    <script define:vars={{ previewKey: PREVIEW_KEY, isDev: import.meta.env.DEV }}>
+      // Unlock drafted articles when the magic preview key is present, and keep
+      // them unlocked for the rest of the session. Dev is always unlocked.
+      (function () {
+        try {
+          let unlocked = isDev || sessionStorage.getItem('bf-preview') === '1';
+          const param = new URLSearchParams(location.search).get('preview');
+          if (param !== null && param === previewKey) {
+            unlocked = true;
+            sessionStorage.setItem('bf-preview', '1');
+          }
+          if (unlocked) document.documentElement.setAttribute('data-preview', 'on');
+        } catch (e) {}
+      })();
     </script>
   </head>
   <body class="bf-body">

--- a/beta/src/components/Nav.astro
+++ b/beta/src/components/Nav.astro
@@ -1,5 +1,4 @@
 ---
-import { getCollection } from 'astro:content';
 import Mark from './Mark.astro';
 import LangToggle from './LangToggle.astro';
 import ThemeToggle from './ThemeToggle.astro';
@@ -12,11 +11,7 @@ interface Props {
 
 const { lang = 'DE', cta, ctaHref = 'mailto:info@bumbleflies.de' } = Astro.props;
 
-// The Blog link only surfaces once at least one article is switched live
-// (published: true). Until then the series stays dark even after deploy.
-const hasBlog = (await getCollection('blog', ({ data }) => data.published)).length > 0;
-
-const baseItems = lang === 'DE'
+const navItems = lang === 'DE'
   ? [
       { label: 'Facilitation · AI · Software', href: '/services' },
       { label: 'AI Consulting', href: '/ai-consulting' },
@@ -29,15 +24,6 @@ const baseItems = lang === 'DE'
       { label: 'remote, hybrid & on-site', href: '/en/how-we-work' },
       { label: 'Why · We', href: '/en/why-we' },
     ];
-
-// Blog is DE-only for now; insert it after AI Consulting so it reads as proof of it.
-const navItems = hasBlog
-  ? [
-      ...baseItems.slice(0, 2),
-      { label: 'Field Notes', href: '/blog' },
-      ...baseItems.slice(2),
-    ]
-  : baseItems;
 
 const brandHref = lang === 'DE' ? '/' : '/en/';
 

--- a/beta/src/components/Nav.astro
+++ b/beta/src/components/Nav.astro
@@ -1,4 +1,5 @@
 ---
+import { getCollection } from 'astro:content';
 import Mark from './Mark.astro';
 import LangToggle from './LangToggle.astro';
 import ThemeToggle from './ThemeToggle.astro';
@@ -11,7 +12,11 @@ interface Props {
 
 const { lang = 'DE', cta, ctaHref = 'mailto:info@bumbleflies.de' } = Astro.props;
 
-const navItems = lang === 'DE'
+// The Blog link only surfaces once at least one article is switched live
+// (published: true). Until then the series stays dark even after deploy.
+const hasBlog = (await getCollection('blog', ({ data }) => data.published)).length > 0;
+
+const baseItems = lang === 'DE'
   ? [
       { label: 'Facilitation · AI · Software', href: '/services' },
       { label: 'AI Consulting', href: '/ai-consulting' },
@@ -24,6 +29,15 @@ const navItems = lang === 'DE'
       { label: 'remote, hybrid & on-site', href: '/en/how-we-work' },
       { label: 'Why · We', href: '/en/why-we' },
     ];
+
+// Blog is DE-only for now; insert it after AI Consulting so it reads as proof of it.
+const navItems = hasBlog
+  ? [
+      ...baseItems.slice(0, 2),
+      { label: 'Field Notes', href: '/blog' },
+      ...baseItems.slice(2),
+    ]
+  : baseItems;
 
 const brandHref = lang === 'DE' ? '/' : '/en/';
 

--- a/beta/src/content.config.ts
+++ b/beta/src/content.config.ts
@@ -20,6 +20,23 @@ const caseStudies = defineCollection({
   }),
 });
 
+const blog = defineCollection({
+  loader: glob({ pattern: '**/*.md', base: './src/content/blog' }),
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+    excerpt: z.string(),
+    category: z.string(),
+    // Series order — controls the reading sequence in the listing.
+    order: z.number(),
+    date: z.coerce.date(),
+    author: z.string().default('bumbleflies'),
+    readingTime: z.string().optional(),
+    // The per-article live switch: false = drafted & ready but not built/listed.
+    published: z.boolean().default(false),
+  }),
+});
+
 const testimonials = defineCollection({
   loader: glob({ pattern: '**/*.md', base: './src/content/testimonials' }),
   schema: z.object({
@@ -48,4 +65,4 @@ const pages = defineCollection({
   schema: pagesSchemaCoerced,
 });
 
-export const collections = { 'case-studies': caseStudies, testimonials, team, pages };
+export const collections = { 'case-studies': caseStudies, blog, testimonials, team, pages };

--- a/beta/src/content.config.ts
+++ b/beta/src/content.config.ts
@@ -27,6 +27,8 @@ const blog = defineCollection({
     description: z.string(),
     excerpt: z.string(),
     category: z.string(),
+    // Teaser/cover image (concrete-scene SVG in /public/images/blog/<slug>.svg).
+    image: z.string().optional(),
     // Series order — controls the reading sequence in the listing.
     order: z.number(),
     date: z.coerce.date(),

--- a/beta/src/content/blog/bots-die-nachts-arbeiten.md
+++ b/beta/src/content/blog/bots-die-nachts-arbeiten.md
@@ -1,0 +1,64 @@
+---
+title: "Bots, die arbeiten, während du schläfst: Claude Code als autonomer Daemon"
+description: "Vier autonome Bots, die einen Team-Chat beobachten, Code implementieren, Pull-Requests öffnen und Hotfixes ausrollen — und die Narben, die jede einzelne Schutzmaßnahme erklären."
+excerpt: "Ein Wort im Chat weckt einen Bot. Er implementiert, öffnet einen PR, meldet sich zurück. Vier Personas aus einem Bausatz. Und die Nacht, in der ein Bot für mehrere hundert Euro Tokens verbrannte."
+category: "Autonomie"
+order: 5
+date: 2026-07-22
+readingTime: "10 Min."
+published: false
+---
+
+Das ist der Artikel, auf den die eingangs zitierte Kundenfrage wirklich zielte: *„Man gibt Feature-Requests textuell ein — und dann laufen Agents los, implementieren das, machen Pull-Requests?"*
+
+Ja. So funktioniert es. Und so haben wir es gebaut.
+
+## Die Grundidee: ein Bot ist Claude Code als Daemon
+
+Ein „Bot" ist nichts anderes als **Claude Code, das als langlebiger Daemon in einem Container läuft** — angetrieben von Chat-Nachrichten statt von einem Menschen am Terminal. Es beobachtet einen Team-Chat-Kanal, und sobald ein Triggerwort fällt, implementiert es Code-Änderungen, öffnet Pull-Requests, adressiert Review-Kommentare, rollt Hotfixes aus oder testet die Anwendung im Browser — alles unbeaufsichtigt.
+
+Die eleganteste Entscheidung steckt in der Architektur: Es gibt vier Personas — einen Entwickler-Bot, einen Support-Bot, einen Produktmanagement-Bot, einen Test-Bot — aber sie sind **nicht vier Codebasen.** Sie sind dieselbe Laufzeit, spezialisiert allein durch einen anderen Systemprompt, eine andere Liste installierter Skills und ein paar Umgebungsvariablen.
+
+> „Ein neuer Bot ist einfach ein Container mit anderen Umgebungsvariablen und einem anderen Systemprompt."
+
+Das ist DRY-Prinzip auf Agenten-Ebene. Eine Verbesserung am gemeinsamen Bausatz erreicht sofort alle vier.
+
+## Der Auslöser: kein Webhook, ein simpler Poll
+
+Man würde erwarten, dass ein solches System über Webhooks getrieben wird. Tut es nicht. Jeder Bot ist eine **30-Sekunden-Poll-Schleife.** Alle 30 Sekunden fragt er den Chat ab: Gibt es eine neue Nachricht mit dem Triggerwort? Ist die Antwort ja, startet er das Sprachmodell. Ist sie nein, schläft er weiter — ohne einen einzigen Token zu verbrennen.
+
+Das klingt unelegant und ist genau deshalb robust: Es gibt keine Webhook-Registrierung, die stillschweigend kaputtgeht, keine nach außen offene Schnittstelle. Und um die gefühlte Latenz zu verstecken, gibt es einen hübschen UX-Trick: Noch bevor das Modell überhaupt startet, postet der Poll eine Vorab-Bestätigung — „Ich kümmere mich drum! 🐳" — die sich alle 15 Sekunden mit dem aktuellen Arbeitsschritt aktualisiert. Der Mensch sieht innerhalb einer Sekunde eine Reaktion, statt zwei Minuten auf den ersten Token zu warten.
+
+## Wie es Claude Code kopflos ausführt
+
+Im Kern ruft der Bootstrap Claude Code im Headless-Modus auf, mit übersprungenen Berechtigungs-Abfragen — der Bot soll ja nicht bei jeder Datei nachfragen. Genau deshalb ist eine der wichtigsten Schutzmaßnahmen ein **harter Stopp per Hook**: Ein Merge nach `master` oder `main` wird kategorisch verweigert.
+
+> „Autonomes Mergen ist deaktiviert … überlasse den Merge einem Menschen."
+
+Der Bot darf pushen, darf Pull-Requests öffnen — aber der Merge in die Hauptlinie bleibt eine menschliche Entscheidung. Das ist die „Hand am Bremshebel", von der sich das ganze System leiten lässt. Weil die Berechtigungen übersprungen sind, muss dieser Stopp ein *harter* Code-Stopp sein — eine bloße Prompt-Regel wäre nur ein Ratschlag, den das Modell im Eifer ignorieren könnte.
+
+## Die Narben — und warum sie das Wertvollste sind
+
+Jetzt zum ehrlichen Teil. Fast jede Schutzmaßnahme in diesem System lässt sich auf einen konkreten, datierten Vorfall zurückführen. Das ist keine Peinlichkeit, sondern die Methode: **Das System wächst, indem es seine eigenen Fehler in Code gießt.**
+
+**Die Nacht mit mehreren hundert Euro Tokens.** Der Chat-Token eines Bots war abgelaufen. Der Poll interpretierte das als „es gibt Arbeit" und feuerte alle 30 Sekunden das Sprachmodell, um das vermeintliche Problem zu „lösen" — die ganze Nacht. Am Morgen: mehrere hundert Euro Token-Kosten für nichts. Die Antwort waren *drei* unabhängige Ausgaben-Wächter: ein stiller Token-Refresh, der zuerst versucht, das Problem ohne Modell zu lösen; eine Fehler-Zustandsmaschine, die nach wiederholten Fehlschlägen auf einen Versuch pro Stunde drosselt; und eine Wochenlimit-Markierung. Seither feuert ein abgelaufener Token *nie* das Modell — er überspringt einfach den Tick.
+
+**Die Konfiguration auf dem Netzlaufwerk.** Anfangs lag die Bot-Konfiguration auf einem persistenten Netzlaufwerk. Dort ging das Klonen und Zurücksetzen des Git-Repositorys immer wieder kaputt, korrumpierte Dateien, und der defekte Ordner ließ sich nicht mehr löschen — der Bot hing fest. Die Lektion: Konfiguration auf flüchtigen lokalen Speicher, der bei jedem Start frisch geklont wird; nur der *Zustand* liegt persistent. Und niemals ein `sleep infinity` im Fehlerfall — lieber sauber beenden und den Container einen frischen Prozess starten lassen.
+
+**Die Selbst-Neustart-Schleife.** Die Bots lernen dazu: Nach einem Review-Kommentar schreiben sie eine neue Regel in ihre Wissensbasis und pushen sie. Anfangs interpretierte die Deployment-Automatik diesen Push als Konfigurations-Änderung — und startete den Bot mitten in der Arbeit neu. Der Neustart wiederholte die Arbeit, lernte, committete, pushte, startete neu … eine unendliche Selbst-Neustart-Schleife. Die Korrektur: Pushes in die Wissensbasis explizit von der Neustart-Logik ausnehmen.
+
+**„Verlasse dich nie auf die Absender-Identität."** Weil der Bot über den Token eines Menschen postet, teilen sich Bot und Mensch einen Anzeigenamen. Ein Vorfall, in dem der Bot auf seine eigene Statusnachricht reagierte — weil darin das Triggerwort vorkam — führte zur Regel: Alles macht sich an Nachrichten-IDs fest, nie an der Anzeige-Identität.
+
+**„Gemacht zählt erst als gelernt, wenn es geschrieben steht."** Der Test-Bot, der die Anwendung im Browser durchklickt, führt eine eigene Wissensbasis über die Oberfläche des Produkts. Der Leitsatz dahinter ist zugleich die vielleicht beste Zusammenfassung des ganzen Ansatzes: Erfahrung, die nirgends notiert wird, ist verloren. Also schreiben die Bots ihre Lektionen auf und pushen sie — deploy-neutral, sofort für alle verfügbar.
+
+## Die selbstlernende Schicht
+
+Genau das ist der Grund, warum diese Bots über die Monate besser werden, statt gleich schlecht zu bleiben: Sie schreiben nach jedem Review, nach jeder Korrektur generalisierbare Regeln in eine Wissensbasis und teilen sie. Der Entwickler-Bot lernt Konventionen des Frontends, der Support-Bot lernt die Choreografie eines Rollouts, der Test-Bot lernt die Eigenheiten der Oberfläche. **Die Werkzeuge verbessern die Dokumente, die die Werkzeuge steuern** — dasselbe Kompound-Muster wie im Marktplatz.
+
+## Was man daraus mitnimmt
+
+Autonome Agenten in Produktion sind kein Magie-Trick. Sie sind ein sehr gewöhnliches Werkzeug (Claude Code) in einer sehr disziplinierten Umgebung: ein billiger Poll statt fragiler Webhooks, harte Code-Grenzen um die riskanten Aktionen, drei unabhängige Kostenwächter, und eine Kultur, in der jeder Vorfall zu einer neuen Regel wird.
+
+Der schwierigste Teil ist nicht, den Bot zum Arbeiten zu bringen. Der schwierigste Teil ist, ihm die Grenzen zu geben, an denen man nachts ruhig schläft. Genau darin steckt die Erfahrung, die man nicht aus einem Tutorial bekommt — sondern nur aus einem Jahr Produktivbetrieb mit echten Narben.
+
+Im letzten Teil der Serie drehen wir die Perspektive um: weg von den Maschinen, die autonom arbeiten, hin zu einem einzelnen Menschen — und dem Cockpit, das dessen Tag mit zehn Agenten orchestriert.

--- a/beta/src/content/blog/bots-die-nachts-arbeiten.md
+++ b/beta/src/content/blog/bots-die-nachts-arbeiten.md
@@ -3,6 +3,7 @@ title: "Bots, die arbeiten, während du schläfst: Claude Code als autonomer Dae
 description: "Vier autonome Bots, die einen Team-Chat beobachten, Code implementieren, Pull-Requests öffnen und Hotfixes ausrollen — und die Narben, die jede einzelne Schutzmaßnahme erklären."
 excerpt: "Ein Wort im Chat weckt einen Bot. Er implementiert, öffnet einen PR, meldet sich zurück. Vier Personas aus einem Bausatz. Und die Nacht, in der ein Bot für mehrere hundert Euro Tokens verbrannte."
 category: "Autonomie"
+image: "/images/blog/bots-die-nachts-arbeiten.svg"
 order: 5
 date: 2026-07-22
 readingTime: "10 Min."

--- a/beta/src/content/blog/cockpit-tag-mit-zehn-agenten.md
+++ b/beta/src/content/blog/cockpit-tag-mit-zehn-agenten.md
@@ -3,6 +3,7 @@ title: "Ein Cockpit für einen Menschen: den eigenen Tag mit zehn Agenten orches
 description: "Zehn parallele Scanner, die aus Mail, Chat, Tickets, Kalender und sogar der eigenen KI-Historie einen priorisierten Tagesplan machen — mit zwei Versprechen: nichts geht verloren, nichts bleibt stecken."
 excerpt: "Die persönliche Seite des Stacks. Ein Meta-Agent, der zehn Quellen scannt, jeden losen Faden gegen die Tickets abgleicht und jede Aufgabe eine Nachricht davon entfernt macht, erledigt zu sein."
 category: "Produktivität"
+image: "/images/blog/cockpit-tag-mit-zehn-agenten.svg"
 order: 6
 date: 2026-07-25
 readingTime: "8 Min."

--- a/beta/src/content/blog/cockpit-tag-mit-zehn-agenten.md
+++ b/beta/src/content/blog/cockpit-tag-mit-zehn-agenten.md
@@ -1,0 +1,65 @@
+---
+title: "Ein Cockpit für einen Menschen: den eigenen Tag mit zehn Agenten orchestrieren"
+description: "Zehn parallele Scanner, die aus Mail, Chat, Tickets, Kalender und sogar der eigenen KI-Historie einen priorisierten Tagesplan machen — mit zwei Versprechen: nichts geht verloren, nichts bleibt stecken."
+excerpt: "Die persönliche Seite des Stacks. Ein Meta-Agent, der zehn Quellen scannt, jeden losen Faden gegen die Tickets abgleicht und jede Aufgabe eine Nachricht davon entfernt macht, erledigt zu sein."
+category: "Produktivität"
+order: 6
+date: 2026-07-25
+readingTime: "8 Min."
+published: false
+---
+
+Die bisherigen Artikel handelten von Systemen, die für viele arbeiten: das Nervensystem, der Marktplatz, die autonomen Bots. Dieser letzte Teil dreht die Perspektive um. Er handelt von einem einzelnen Menschen und der Frage, die jeder Wissensarbeiter jeden Morgen hat: *Was ist heute eigentlich wichtig — und was habe ich vergessen?*
+
+Die Antwort ist ein persönlicher Meta-Agent, den wir „Cockpit" nennen. Er zieht jeden Arbeitskontext zusammen — Mail, Chat, Tickets, Video-Calls, Support-Postfach, Kalender, Aktivitätsprotokoll, lokale Verzeichnisse, den Agenten-Bus — und macht daraus einen priorisierten Tagesplan und *eine* nächste Handlung.
+
+## Zwei Versprechen tragen das ganze Design
+
+Alles am Cockpit folgt aus zwei Zusagen:
+
+1. **Nichts geht verloren.** Jeder lose Faden aus jeder Quelle wird gegen die Tickets abgeglichen — und wenn er nirgends erfasst ist, in ein Eingangs-Ticket geroutet.
+2. **Nichts bleibt stecken.** Jede aufgetauchte Aufgabe kommt mit einem fertig einfügbaren Fortsetzungs-Befehl, sodass sie „eine Nachricht davon entfernt ist, erledigt zu sein".
+
+Diese zwei Sätze klingen simpel. Ihre Umsetzung ist die eigentliche Ingenieurskunst.
+
+## Zehn Scanner, parallel, die niemals scheitern
+
+Das Herz ist ein Fächer aus zehn **Scannern** — je einer pro Quelle, alle gleichzeitig gestartet. Jeder Scanner bekommt denselben Auftrag und muss ein streng strukturiertes JSON-Ergebnis zurückgeben.
+
+Die wichtigste Regel dabei: Ein Scanner **scheitert nie.** Wenn eine Quelle nicht erreichbar ist, gibt er keinen Fehler zurück, sondern ein sauberes „nicht verfügbar, Grund: …". Damit kann eine tote Quelle niemals den ganzen Lauf abbrechen. Das ist dieselbe Fehlertoleranz-Philosophie wie im Nervensystem: Das System degradiert würdevoll, statt umzukippen.
+
+Und weil das strukturierte Ergebnis strikt validiert wird, bevor irgendetwas ihm vertraut, kann ein einzelner Scanner, der halluziniert oder Müll liefert, den Plan nicht vergiften. **Vertraue dem Modell nicht — verifiziere mit Code**, auch hier.
+
+## Der Scanner, der die eigene KI-Historie liest
+
+Ein Detail hebt das Cockpit heraus. Einer der zehn Scanner liest die **eigene Gesprächshistorie von Claude Code** — die Protokolle der KI-Sitzungen des Menschen. Warum? Weil dort Verpflichtungen liegen, die man mündlich gegenüber der KI eingegangen ist („ich mache später X"), offene Fragen, angefangene Arbeitsschritte. Der Scanner holt diese in Arbeit befindlichen Zusagen zurück an die Oberfläche, damit sie nicht im Sitzungsverlauf versickern.
+
+Ein Agent, der über die Arbeit eines Menschen mit anderen Agenten reflektiert — das ist die vielleicht unerwartetste, aber logischste Konsequenz eines Systems, in dem Mensch und KI ständig zusammenarbeiten.
+
+## „Gelesen heißt nicht erledigt"
+
+Meine liebste Regel im Cockpit stammt, wie so vieles im System, aus einem echten Vorfall. Der Mail-Scanner listet nicht nur ungelesene, sondern auch *gelesene* Mails. Denn: **Gelesen heißt nicht erledigt.** Eine gelesene Mail, bei der die Gegenseite zuletzt geschrieben hat und die eine Bitte oder eine Lieferung enthält, ist weiterhin offene Arbeit.
+
+Dahinter steht eine konkrete Regression: eine Beispieldatei, gelesen an einem Montag, aber erst zwei Tage später manuell bemerkt — weil „gelesen" fälschlich als „erledigt" galt. Die Regel ist die Narbe dieser zwei verlorenen Tage. Genau solche Regeln machen den Unterschied zwischen einem Assistenten, der beeindruckt, und einem, dem man vertraut.
+
+## Blockiert, wartend, als Nächstes
+
+Das Cockpit unterscheidet sauber drei Zustände, die die meisten Menschen im Kopf vermischen:
+
+- **Blockiert** — es fehlt Zugang, Daten oder eine Voraussetzung. Kann hoch priorisiert sein, aber nie „als Nächstes" dran sein.
+- **Wartend** — wir schulden noch eine Nachverfolgung, aber jemand anderes muss zuerst handeln.
+- **Nächste Handlung** — der einzige höchstbewertete Faden, der *weder* blockiert *noch* wartend ist.
+
+Diese Unterscheidung ist der Grund, warum die „nächste Handlung" immer wirklich machbar ist. Ein blockierter Punkt drängt sich nicht als To-do auf, das man sowieso nicht angehen kann.
+
+## DRY, sogar hier
+
+Auch das Cockpit folgt dem Prinzip „eine Definition, viele Laufzeiten". Es teilt sich eine Konfiguration und einen gemeinsamen Speicher mit einem leichteren Geschwister-Skill, der in jedem Projekt verfügbar ist. Und seine Scanner rufen dieselben Kommunikations-Skills aus dem Marktplatz auf, die auch die Bots benutzen. Das Cockpit ist kein Solitär — es sitzt auf demselben Fundament wie der Rest des Systems und liest dieselben zwei Ebenen.
+
+## Der Bogen schließt sich
+
+Damit schließt sich der Kreis dieser Serie. Wir sind bei den zwei Fundament-Ebenen gestartet, über das Nervensystem und den Skill-Marktplatz zu den autonomen Bots gegangen — und landen bei einem einzelnen Menschen, dessen Tag von zehn Agenten orchestriert wird, die alle dieselbe Sprache sprechen.
+
+Das ist der eigentliche Punkt: Es ist *ein* System. Ein Mensch, ein Bot und ein zeitgesteuerter Job benutzen dasselbe Vokabular, dieselben Tickets, dieselben Skills. Nicht weil es elegant aussieht, sondern weil nur so aus einzelnen KI-Tricks ein Betriebssystem wird, das trägt.
+
+Und genau das ist es, was wir bauen. Nicht die Demo, die beeindruckt. Das System, das läuft — Tag und Nacht, mit der Hand am Bremshebel. Wenn Sie die romantische Vorstellung haben, dass da ein Schatz liegt: Sie haben recht. Reden wir darüber, wie er in Ihrem Unternehmen aussieht.

--- a/beta/src/content/blog/ki-agenten-betriebssystem.md
+++ b/beta/src/content/blog/ki-agenten-betriebssystem.md
@@ -3,6 +3,7 @@ title: "Ein KI-Agenten-Betriebssystem für ein Legal-Tech-Unternehmen"
 description: "Nicht 'wir haben KI gekauft', sondern 'wir haben unsere eigenen Betriebsabläufe in Code übersetzt, den ein Sprachmodell komponiert'. Die Landkarte eines echten Agenten-Systems in Produktion."
 excerpt: "Vier Agenten-Schichten auf zwei Fundament-Ebenen. Autonome Bots, die Pull-Requests öffnen, ein Skill-Marktplatz für Firmenwissen, ein Cockpit, das den Tag plant. So sieht KI aus, wenn sie nicht in der Demo endet."
 category: "Überblick"
+image: "/images/blog/ki-agenten-betriebssystem.svg"
 order: 1
 date: 2026-07-10
 readingTime: "9 Min."

--- a/beta/src/content/blog/ki-agenten-betriebssystem.md
+++ b/beta/src/content/blog/ki-agenten-betriebssystem.md
@@ -1,0 +1,84 @@
+---
+title: "Ein KI-Agenten-Betriebssystem für ein Legal-Tech-Unternehmen"
+description: "Nicht 'wir haben KI gekauft', sondern 'wir haben unsere eigenen Betriebsabläufe in Code übersetzt, den ein Sprachmodell komponiert'. Die Landkarte eines echten Agenten-Systems in Produktion."
+excerpt: "Vier Agenten-Schichten auf zwei Fundament-Ebenen. Autonome Bots, die Pull-Requests öffnen, ein Skill-Marktplatz für Firmenwissen, ein Cockpit, das den Tag plant. So sieht KI aus, wenn sie nicht in der Demo endet."
+category: "Überblick"
+order: 1
+date: 2026-07-10
+readingTime: "9 Min."
+published: false
+---
+
+Die häufigste Frage, die uns Unternehmen zum Thema KI stellen, klingt ungefähr so:
+
+> „Gehe ich richtig in der Annahme, dass man Feature-Requests einfach textuell eingibt — und dann laufen Agents los, implementieren das, machen Pull-Requests? Ich habe die romantische Vorstellung, dass ihr da einen aktuellen Schatz habt."
+
+Das ist ein echtes Zitat aus einer Kundenanfrage. Und die ehrliche Antwort lautet: Ja. Genau das haben wir gebaut — nicht als Demo, nicht als Proof-of-Concept, sondern als produktives System, das seit über einem Jahr den Arbeitsalltag eines deutschen Legal-Tech-Unternehmens trägt.
+
+Diese Artikelserie beschreibt dieses System. Wie es aufgebaut ist, welche Entscheidungen wir getroffen haben — und vor allem die Narben, denn fast jede Schutzmaßnahme darin lässt sich auf einen konkreten Vorfall zurückführen.
+
+## Der Kern: keine gekaufte KI, sondern kompilierte Betriebsabläufe
+
+Der wichtigste Satz zuerst, weil er alles andere erklärt: Wir haben keine KI-Lösung *eingekauft*. Wir haben die **operativen Verfahren des Unternehmens in Code übersetzt, den ein Sprachmodell zusammensetzt.**
+
+Der Unterschied ist fundamental. Ein generischer KI-Assistent weiß nichts über Ihre Deployment-Pipeline, Ihre Ticket-Konventionen, Ihre Freigabe-Regeln, Ihre Kundenlandschaft. Er improvisiert — und improvisiert jedes Mal ein bisschen anders. Ein System, das Ihre Verfahren als versionierten, testbaren Code kennt, tut jedes Mal dasselbe. Das Sprachmodell trifft die Urteilsentscheidungen; deterministische Skripte führen die Mechanik aus.
+
+Aus dieser einen Idee ist ein mehrschichtiges Betriebssystem gewachsen.
+
+## Die Architektur: zwei Ebenen, vier Schichten
+
+Das mentale Modell hat **zwei rechtwinklige Fundament-Ebenen** und **vier Agenten-Schichten**, die darauf operieren.
+
+**Die Zustandsebene** ist das Projektmanagement-Tool (in unserem Fall ClickUp). Jede Arbeit wird als Ticket geboren oder gegen ein Ticket abgeglichen. Ein Statuswechsel, ein neuer Kommentar, ein geändertes Feld — jedes ist ein Ereignis, das Aktionen auslöst. Das ist der dauerhafte Speicher der Wahrheit *und* die Zündung.
+
+**Die Interaktionsebene** ist der Team-Chat (Microsoft Teams). Hier trifft Autonomie auf Menschen: Hier lösen Menschen Agenten aus, hier melden Agenten ihren Status zurück, und hier koordinieren sich Agenten untereinander.
+
+Darauf sitzen die vier Schichten:
+
+- **Schicht 1 — das Nervensystem.** Eine Automatisierungsplattform (n8n) reagiert auf Ereignisse der Zustandsebene und steuert die Interaktionsebene sowie andere Systeme. Kein Mensch in der Schleife. 24 Workflows, knapp 700 Verarbeitungsschritte. Hier entsteht z. B. aus einer Support-E-Mail automatisch ein klassifiziertes, entdupliziertes Ticket.
+
+- **Schicht 2 — der Skill-Marktplatz.** Das Firmenwissen als installierbare, versionierte „Apps". 11 Plugins, 53 Skills. Jeder Skill ist die Kombination aus Modell-Urteil und deterministischem Skript — und funktioniert identisch für einen Menschen am Laptop, einen Bot im Container und die CI-Pipeline.
+
+- **Schicht 3 — die autonomen Bots.** Claude Code, das rund um die Uhr als Daemon läuft. Ein Wort im Team-Chat weckt einen Bot; er implementiert Code, öffnet Pull-Requests, adressiert Review-Kommentare, rollt Hotfixes aus — und meldet sich zurück. Vier Personas aus *einem* gemeinsamen Bausatz.
+
+- **Schicht 4 — das persönliche Cockpit.** Ein Meta-Agent, der zehn Quellen parallel scannt und daraus den Tag eines Menschen plant. Er liest beide Fundament-Ebenen — und sogar die eigene Gesprächshistorie der KI, um offene Fäden wiederzufinden.
+
+## Das Verbindungsgewebe
+
+Der eigentlich interessante Punkt: Das sind keine vier getrennten Projekte. Es ist ein **Netz mit benannten, tragenden Nähten** — und fast jede Verbindung läuft über die zwei Fundament-Ebenen. Komponenten stoßen sich gegenseitig über Chat-Nachrichten an und koordinieren sich über Tickets und Kommentare, statt sich direkt aufzurufen. Die Ebenen *sind* das gemeinsame Vokabular.
+
+Ein durchgängiger Ablauf, wie er täglich passiert:
+
+1. Ein Kunde schreibt an den Support. Das Nervensystem erzeugt daraus automatisch ein KI-klassifiziertes Ticket.
+2. Jemand tippt im Team-Chat ein Triggerwort. Der Support-Bot wacht auf, sichtet die offenen Pull-Requests, triagiert sie.
+3. Nach expliziter menschlicher Freigabe rollt der Bot aus — erst die Datenbank-Migrationen, dann die Services.
+4. Der Bot hinterlässt einen Kommentar am Ticket; das Nervensystem generiert daraus die kundensichtbaren Release-Notes — durch einen mehrstufigen Datenschutz-Filter.
+5. Am nächsten Morgen taucht der gesamte Vorgang im Tagesbriefing des Cockpits auf, dedupliziert gegen die Tickets.
+
+Vier Schichten, ein Arbeitsvorgang. Kein einziger Direktaufruf zwischen den Komponenten.
+
+## Die wiederkehrenden Prinzipien
+
+Über alle Schichten hinweg tauchen dieselben Entwurfsprinzipien auf. Sie sind der eigentliche Wert — und der rote Faden dieser Serie:
+
+**Vertraue dem Modell nicht — verifiziere mit Code.** Die durchgängige Antwort auf „Wie macht man ein Sprachmodell in Produktion sicher?" lautet: eine deterministische Grenze drumherum ziehen. Das Modell schreibt, ein Regex-Filter prüft, das Modell korrigiert, derselbe Filter prüft erneut — und verweigert im Zweifel hart.
+
+**Narben als Design.** Fast jede Schutzmaßnahme zitiert einen datierten Vorfall: eine Nacht, in der ein Bot für mehrere hundert Euro Tokens verbrannte, eine Regression bei der Terminbuchung, eine defekte Konfiguration auf einem Netzlaufwerk. Die Systeme wachsen, indem sie ihre eigenen Fehler in Regeln gießen.
+
+**Koordination über dauerhafte Artefakte, nicht über RPC.** Agenten und Menschen sprechen über Tickets, Tags, Status und Chat-Nachrichten miteinander — nachvollziehbar, wiederaufnehmbar, für Menschen einsehbar.
+
+**Eine Definition, viele Laufzeiten.** Ein Skill, N Bot-Personas. Ein Skript für Mensch, Bot und CI. Kein Copy-Paste.
+
+**Mensch am Bremshebel.** Deutschsprachige Trigger überall, Rechts-Domäne, und alle wirklich folgenreichen Aktionen — Freigaben, Merges, Produktiv-Deployments — sind an eine explizite menschliche Bestätigung gebunden. Autonomie mit der Hand am Hebel.
+
+## Was in dieser Serie kommt
+
+Die folgenden Artikel gehen je eine Ebene tief:
+
+- **Die zwei Ebenen**, auf denen alles läuft — warum der ganze Stack über zwei SaaS-Tools koordiniert statt über eigene Services.
+- **Das Nervensystem** — Event-Automatisierung und der Datenschutz-Filter als Musterbeispiel für „verifiziere mit Code".
+- **Skills als Apps** — der Plugin-Marktplatz für Firmenwissen.
+- **Bots, die nachts arbeiten** — Claude Code als autonomer Daemon, und die Narben.
+- **Ein Cockpit für einen Menschen** — den eigenen Tag mit zehn Agenten orchestrieren.
+
+Das ist keine Zukunftsvision. Das läuft. Und der Grund, warum wir es aufschreiben, ist einfach: Weil die romantische Vorstellung, dass da irgendwo ein Schatz liegt, stimmt — und weil wir ihn für andere Unternehmen genauso heben können.

--- a/beta/src/content/blog/nervensystem-n8n-automatisierung.md
+++ b/beta/src/content/blog/nervensystem-n8n-automatisierung.md
@@ -3,6 +3,7 @@ title: "Das Nervensystem: Event-Automatisierung — und wie man ein Sprachmodell
 description: "Wie ein always-on Automatisierungslayer aus Support-Mails klassifizierte Tickets macht, und der mehrstufige Datenschutz-Filter, der das beste Beispiel für 'vertraue dem Modell nicht, verifiziere mit Code' ist."
 excerpt: "24 Workflows, knapp 700 Verarbeitungsschritte, kein Mensch in der Schleife. Ein selbstlernender Ticket-Router und ein Datenschutz-Filter, der das Sprachmodell schreiben lässt — aber ihm kein Wort glaubt."
 category: "Automatisierung"
+image: "/images/blog/nervensystem-n8n-automatisierung.svg"
 order: 3
 date: 2026-07-15
 readingTime: "9 Min."

--- a/beta/src/content/blog/nervensystem-n8n-automatisierung.md
+++ b/beta/src/content/blog/nervensystem-n8n-automatisierung.md
@@ -1,0 +1,58 @@
+---
+title: "Das Nervensystem: Event-Automatisierung — und wie man ein Sprachmodell ehrlich hält"
+description: "Wie ein always-on Automatisierungslayer aus Support-Mails klassifizierte Tickets macht, und der mehrstufige Datenschutz-Filter, der das beste Beispiel für 'vertraue dem Modell nicht, verifiziere mit Code' ist."
+excerpt: "24 Workflows, knapp 700 Verarbeitungsschritte, kein Mensch in der Schleife. Ein selbstlernender Ticket-Router und ein Datenschutz-Filter, der das Sprachmodell schreiben lässt — aber ihm kein Wort glaubt."
+category: "Automatisierung"
+order: 3
+date: 2026-07-15
+readingTime: "9 Min."
+published: false
+---
+
+Wenn die zwei Fundament-Ebenen — Tickets und Chat — das Skelett des Systems sind, dann ist die Automatisierungsschicht das Nervensystem: immer wach, ereignisgetrieben, ohne Menschen in der Schleife. Sie reagiert auf jede Veränderung an einem Ticket und steuert daraus die anderen Systeme.
+
+Wir haben diese Schicht mit n8n gebaut, einer Open-Source-Automatisierungsplattform. 24 Workflows, knapp 700 Verarbeitungsschritte. Sie verwandelt eine Support-Mail in ein klassifiziertes Ticket, ein Call-Recording in eine strukturierte Aufgabenliste, einen Kommentar in fertige Release-Notes. Zwei dieser Workflows verdienen einen genaueren Blick, weil sie zwei Prinzipien verkörpern, die für jedes KI-System gelten.
+
+## Erstens: der Code ist die Wahrheit, nicht die Handarbeit
+
+Die prägende Entscheidung dieser Schicht: Für jeden nicht-trivialen Workflow ist die exportierte Konfiguration zwar die Quelle der Wahrheit — aber sie wird nicht von Hand geschrieben. Ein kleines Python-Skript *erzeugt* sie.
+
+Warum? Weil das Hand-Editieren großer Workflow-Definitionen immer wieder dieselben Fehler produziert: falsche Knoten-IDs, kaputte Verbindungs-Arrays, Typ-Verwechslungen. Ein Generator-Skript macht diese Fehler nicht. Beide — Generator und erzeugte Konfiguration — liegen im Git. Das ist dieselbe Philosophie, die den ganzen Stack durchzieht: **Wo etwas deterministisch sein kann, soll es ein Skript sein.**
+
+## Zweitens: ein Router, der aus menschlichen Korrekturen lernt
+
+Der Support-Workflow ist ein selbstverbessernder Kreislauf aus zwei Teilen.
+
+Der erste Teil fängt jede neue Support-Konversation ab und legt daraus ein Ticket an. Dann klassifiziert ein Sprachmodell das Ticket: In welche Liste gehört es? Die Klassifikation läuft als **Few-Shot-Prompt** — das Modell bekommt Beispiele vergangener Tickets mit der Liste, in die sie einsortiert wurden. Ist es sich zu mehr als 75 % sicher, verschiebt es das Ticket automatisch. Ist es unsicher, bleibt das Ticket im Eingang liegen.
+
+Der zweite Teil schließt den Kreis: Immer wenn ein *Mensch* ein Ticket manuell aus dem Eingang verschiebt, wird genau diese Korrektur als neues Beispiel gespeichert. Die Trainingsdaten des Routers *sind* das Protokoll der menschlichen Korrekturen. Es gibt keinen separaten Labeling-Schritt. Am ersten Tag, mit leerer Beispiel-Tabelle, überspringt das System das Modell einfach und lässt alles im Eingang — und lernt ab der ersten manuellen Verschiebung.
+
+Das ist ein Muster, das sich verallgemeinern lässt: **Die beste Trainingsquelle für Ihre KI ist die tägliche Korrektur durch Ihr Team.** Man muss sie nur einfangen.
+
+Und das Ganze ist an jeder Verzweigung fehlertolerant entworfen: Schlägt die Klassifikation fehl, wurde das Ticket ja bereits im Eingang angelegt — ein sicherer Rückfall. Nichts geht verloren, nur weil das Modell mal patzt.
+
+## Das Musterbeispiel: der Datenschutz-Filter
+
+Jetzt zum wichtigsten Baustein — dem, den wir jedem zeigen, der fragt, wie man ein Sprachmodell in Produktion sicher macht.
+
+Das Unternehmen generiert kundensichtbare Release-Notes automatisch aus internen Tickets. Diese Notes sind **für jeden Mandanten öffentlich sichtbar**. Ein Ticket kann aber Mandantennamen, Personennamen, E-Mail-Adressen, Fall-IDs enthalten. Ein Sprachmodell, das aus so einem Ticket eine Release-Note schreibt, könnte diese Daten durchlassen. Das darf nie passieren.
+
+Die naive Lösung wäre: dem Modell im Prompt sagen „nenne keine Namen". Wir tun das auch — der Prompt enthält ein hartes Verbot mit Beispielen. **Aber wir vertrauen dem Prompt nicht.** Der Ablauf ist ein Verteidigungswall in Tiefe:
+
+1. **Das Modell schreibt** die Release-Note — mit der Anweisung, alles zu generalisieren.
+2. **Ein deterministischer Filter prüft** das Ergebnis nach: Regex-Suchen nach E-Mails, URLs, Telefonnummern, IDs. Plus eine Heuristik, die groß geschriebene Wörter außerhalb des Satzanfangs, die nicht auf einer kleinen Erlaubnisliste stehen, als wahrscheinliche Namen markiert.
+3. **Ist der Filter ausgelöst, redigiert ein zweites Modell** die markierten Stellen — es soll jeden markierten Begriff entfernen oder verallgemeinern.
+4. **Derselbe Filter läuft ein zweites Mal.**
+5. **Löst er *immer noch* aus, verweigert der Workflow hart** und postet stattdessen einen Kommentar: „Sanitizer konnte sensible Inhalte nicht entfernen — bitte manuell umschreiben."
+
+Der Kern in einem Satz: **Modell schreibt → Code prüft → Modell korrigiert → Code prüft erneut → im Zweifel harte Verweigerung.** Das Sprachmodell wird eingesetzt, wo es glänzt (flüssig formulieren, verallgemeinern), aber der eingezäunte Bereich ist eng, und die Grenze ist deterministischer Code, kein weiteres Modell.
+
+Der Filter-Code ist übrigens bewusst an zwei Stellen wortgleich dupliziert — mit dem Kommentar „halte diesen Block mit dem anderen synchron". Manchmal ist Redundanz die richtige Entscheidung.
+
+## Der rote Faden
+
+Wenn Sie aus dieser Schicht eine Sache mitnehmen, dann diese: Der Wert eines KI-Systems in Produktion liegt nicht darin, dem Modell mehr zuzutrauen. Er liegt darin, **präzise zu wissen, wo das Modell entscheiden darf — und wo ein deterministischer Zaun steht.**
+
+Das Nervensystem zeigt beide Muster: einen Router, der aus menschlichen Korrekturen klüger wird, und einen Filter, der dem Modell kein einziges Wort glaubt. Beides zusammen ergibt ein System, dem man nachts vertrauen kann.
+
+Im nächsten Teil geht es um die Schicht darüber: den Marktplatz, der Firmenwissen in installierbare Skills verpackt — die „Apps", die Menschen *und* Bots benutzen.

--- a/beta/src/content/blog/skills-als-apps-plugin-marktplatz.md
+++ b/beta/src/content/blog/skills-als-apps-plugin-marktplatz.md
@@ -3,6 +3,7 @@ title: "Skills als Apps: ein Plugin-Marktplatz für Firmenwissen"
 description: "Ein interner App-Store für KI-Tooling: der Marktplatz ist der Store, jedes Plugin eine App, jeder Skill ein Feature. Und die eine Regel, die alles zusammenhält — Modell-Urteil plus deterministisches Skript."
 excerpt: "11 Plugins, 53 Skills, die per natürlicher Sprache aktiviert werden. Derselbe Code läuft für den Menschen am Laptop, den Bot im Container und die CI. Wie man Firmenwissen versioniert statt kopiert."
 category: "Plattform"
+image: "/images/blog/skills-als-apps-plugin-marktplatz.svg"
 order: 4
 date: 2026-07-18
 readingTime: "8 Min."

--- a/beta/src/content/blog/skills-als-apps-plugin-marktplatz.md
+++ b/beta/src/content/blog/skills-als-apps-plugin-marktplatz.md
@@ -1,0 +1,63 @@
+---
+title: "Skills als Apps: ein Plugin-Marktplatz für Firmenwissen"
+description: "Ein interner App-Store für KI-Tooling: der Marktplatz ist der Store, jedes Plugin eine App, jeder Skill ein Feature. Und die eine Regel, die alles zusammenhält — Modell-Urteil plus deterministisches Skript."
+excerpt: "11 Plugins, 53 Skills, die per natürlicher Sprache aktiviert werden. Derselbe Code läuft für den Menschen am Laptop, den Bot im Container und die CI. Wie man Firmenwissen versioniert statt kopiert."
+category: "Plattform"
+order: 4
+date: 2026-07-18
+readingTime: "8 Min."
+published: false
+---
+
+Jedes Unternehmen hat Verfahren, die im Kopf einzelner Leute stecken. Wie man ein Feature von der Idee bis zum Pull-Request bringt. Wie man einen Kunden von einem Altsystem migriert. Wie man einen Hotfix ausrollt, ohne die Produktion umzuwerfen. Dieses Wissen wird normalerweise mündlich weitergegeben, in veralteten Wiki-Seiten begraben oder von Person zu Person kopiert — jedes Mal ein bisschen anders.
+
+Wir haben es stattdessen in einen **internen App-Store** verpackt. Die Metapher ist wörtlich gemeint: der Marktplatz ist der Store, jedes Plugin ist eine App, und jeder Skill darin ist ein Feature.
+
+## Wie es sich anfühlt
+
+Ein Mitarbeiter fügt den Marktplatz einmal pro Rechner zu seinem Claude Code hinzu und installiert die Plugins, die er braucht. Danach aktivieren sich die Skills über **natürliche Sprache**: Man beschreibt, was man will, und Claude Code wählt den passenden Skill anhand seiner Beschreibung. Die Beschreibungen sind bewusst mit Trigger-Phrasen auf Deutsch *und* Englisch gefüllt — „deploy to prd" und „nach prd deployen" führen zum selben Skill. Es ist ein Legal-Tech-Unternehmen mit deutschsprachigem Team; die Sprache muss stimmen.
+
+11 Plugins, 53 Skills. Sie reichen von der Feature-Entwicklung (Planen, Bauen, Reviewen, Testen) über Code-Review für drei verschiedene Technologie-Stacks bis zu Kunden-Onboarding, Support-Fixes und Zeiterfassung.
+
+## Die eine Regel: Modell-Urteil plus deterministisches Skript
+
+Wenn Sie sich aus diesem Artikel eine Sache merken, dann diese Regel — sie ist das architektonische Herzstück des ganzen Systems:
+
+> Jeder Teil eines Skills, der deterministisch gemacht werden kann, SOLL ein Skript sein. Das Sprachmodell komponiert nur den Aufruf.
+
+Ein Skill ist also nie „das Modell macht das schon irgendwie". Ein Skill ist: Das Modell trifft die Urteilsentscheidung (Welche Services sind vom Deployment betroffen? Ist dieser Review-Kommentar erledigt oder offen?), und ein deterministisches Skript führt die Mechanik aus.
+
+Die Begründung ist glasklar:
+
+- **Determinismus** — kein „das Modell hat diesmal Schritt 4 vergessen".
+- **Auditierbarkeit** — man diffed das Skript, nicht einen KI-Gesprächsverlauf.
+- **Geschwindigkeit und Kosten** — ein Skript läuft in Millisekunden und verbrennt keine Tokens.
+- **Wiederverwendbarkeit** — Mensch, Bot und CI rufen dasselbe Skript auf.
+
+Jedes Skript liegt in zwei Varianten vor: einer für Linux/Mac (die Bot-Container, die CI) und einer für Windows (die Laptops). Gleiche Argumente, gleicher Exit-Code, gleiche Ausgabe. Dadurch funktioniert *derselbe* Skill identisch für einen Menschen unter Windows, einen Bot im Linux-Container und die CI-Pipeline. **Eine Definition, viele Laufzeiten.**
+
+## Ein Beispiel für die Raffinesse: der Deploy-Dreiklang
+
+Nehmen wir das Deployment. Drei Skills bilden zusammen einen Mini-Compiler:
+
+Der erste nimmt eine Menge geänderter Dateien und ordnet jede ihrem Deployment-Ziel zu — erkennt neue Datenbank-Migrationen, bildet daraus einen strukturierten Deploy-Plan. Der zweite führt diesen Plan gegen eine Test-Umgebung aus. Der dritte zielt immer auf die Produktion, feuert die Datenbank-Migrationen zuerst als harte Sperre ab und danach die Services parallel.
+
+Der clevere Teil: Der Produktiv-Deploy ist **auslieferungs-agnostisch**. Er weiß nicht, ob ihn ein Mensch, ein Rollout-Skript oder ein Bot aufgerufen hat. Er gibt in dem Moment, in dem eine Produktions-Freigabe ansteht, ein strukturiertes Ereignis aus — „Freigabe nötig" — und überlässt es dem Aufrufer, das dem Menschen zu präsentieren. Genau dieses Design ist der Grund, warum ein und derselbe Skill einen Menschen, ein Rollout und einen autonomen Bot identisch bedienen kann.
+
+## Wissen, das sich selbst verbessert
+
+Das schönste Muster im Marktplatz ist eine Lernschleife. Der Migrations-Playbook-Skill, der Kunden von Altsystemen übernimmt, liest und schreibt ein einziges kanonisches Dokument. Nach jeder Migration hängt ein „Lernen-einfangen"-Schritt die neuen Erkenntnisse an genau dieses Dokument an — und schlägt Änderungen an seinen eigenen Regeln und Aufwands-Tabellen vor.
+
+Das heißt: **Das Werkzeug verbessert das Dokument, das das nächste Werkzeug steuert.** Jede Migration macht das Playbook besser, statt ein Einzelfall zu bleiben. Wissen kompoundiert, statt zu verwittern.
+
+## Analytics als erstklassiger Release-Schritt
+
+Ein Detail, das zeigt, wie ernst „interner Produkt-Store" gemeint ist: Jeder neue Skill *muss* im Nutzungs-Dashboard registriert werden. Ohne diese Registrierung sammelt das System keine Daten darüber, welche Skills tatsächlich benutzt werden — und ohne diese Daten kann man nicht priorisieren, was man verbessert. Analytics ist kein Nachgedanke, sondern ein Pflicht-Schritt jeder Veröffentlichung.
+
+Und die Qualitätssicherung? Jeder Skill, der geändert wird, durchläuft in der CI eine **echte Integrations-Prüfung** — sie ruft den Skill end-to-end als echten Subprozess auf und prüft seine strukturierte Ausgabe. Keine Mocks. Wenn ein Skill kaputt ist, fällt das auf, bevor er jemanden erreicht.
+
+## Warum das für Sie relevant ist
+
+Der Marktplatz löst ein Problem, das jedes wachsende Unternehmen hat: Wissen verteilt sich, driftet auseinander, geht verloren. Die übliche Antwort sind Dokumentationen, die niemand liest. Unsere Antwort: Firmenwissen als installierbare, versionierte, getestete Skills, die per natürlicher Sprache benutzbar sind — von Menschen und von Maschinen, mit exakt demselben Code.
+
+Und genau dieser gemeinsame Code ist die Brücke zum nächsten Teil: Wenn ein Mensch und ein autonomer Bot dieselben Skills ausführen, dann ist ein Bot nur noch ein Container mit einem anderen Systemprompt. Wie das aussieht — und welche teuren Fehler uns dorthin geführt haben — im nächsten Artikel.

--- a/beta/src/content/blog/zwei-ebenen-zustand-und-interaktion.md
+++ b/beta/src/content/blog/zwei-ebenen-zustand-und-interaktion.md
@@ -1,0 +1,63 @@
+---
+title: "Die zwei Ebenen, auf denen alles läuft: Zustand und Interaktion"
+description: "Warum ein ganzes KI-Agenten-System über zwei Standard-SaaS-Tools koordiniert statt über eigene Microservices — und was das über robuste Agenten-Architektur verrät."
+excerpt: "Das Projektmanagement-Tool ist der Speicher der Wahrheit und die Zündung. Der Team-Chat ist die Interaktions- und Transportschicht. Agenten koordinieren sich über dauerhafte Artefakte, nicht über direkte Aufrufe."
+category: "Architektur"
+order: 2
+date: 2026-07-12
+readingTime: "8 Min."
+published: false
+---
+
+Wenn man ein System aus autonomen Agenten baut, ist die verführerischste Idee, sie direkt miteinander reden zu lassen. Bot A ruft eine API von Bot B auf, der schickt eine Nachricht an Dienst C. Nach ein paar Wochen hat man ein Geflecht aus Direktaufrufen, das niemand mehr überblickt, das bei jedem Neustart Zustand verliert und das man nicht nachvollziehen kann, wenn nachts etwas schiefgeht.
+
+Wir haben es anders gemacht. Das gesamte Agenten-System eines deutschen Legal-Tech-Unternehmens koordiniert über **zwei Fundament-Ebenen aus Standard-Tools** — und fast keine Komponente ruft eine andere direkt auf.
+
+## Ebene A: das Projektmanagement-Tool als Zustandsebene
+
+Die erste Ebene ist ClickUp — das Projektmanagement-Tool, in dem das Unternehmen ohnehin arbeitet. Es ist zweierlei zugleich: der **dauerhafte Speicher der Wahrheit** und die **Zündung** für Automatisierung.
+
+Jedes Arbeitselement wird als Ticket geboren oder gegen ein Ticket abgeglichen. Und jede Veränderung an einem Ticket ist ein Ereignis: ein Statuswechsel per Drag-and-Drop, ein neuer Kommentar, ein geändertes Feld. Vier solcher Ereignistypen — Ticket erstellt, verschoben, kommentiert, aktualisiert — zünden praktisch jede Automatisierung im ganzen Stack. Das Prinzip heißt schlicht: **Veränderung → Aktion.**
+
+Drei Details, die aus der Praxis stammen und die zeigen, dass „ein Ticket-Tool als Datenbank benutzen" mehr Disziplin verlangt, als es klingt:
+
+- **Der Kommentar-Befehlsbus.** Kommentare, deren erstes Wort ein festes Steuerwort ist, werden zu Kommandos. Ein Mensch kann sie tippen, ein Bot kann sie posten, und beide sind für immer im Ticket protokolliert. Die gesamte Release-Pipeline wird über diesen einen, auditierbaren Kanal gesteuert — kein separates Dashboard, keine versteckte API.
+
+- **Sentinel-Kommentare als Zustand.** Maschinenlesbare Marker in Kommentaren tragen wiederaufnehmbaren Zustand über Sitzungsgrenzen hinweg. Wenn ein Bot mitten in einem mehrstündigen Rollout neu startet, liest er aus diesen Markern, wo er war. Der Zustand lebt im Ticket, nicht im Arbeitsspeicher eines Prozesses.
+
+- **Kein globales „erledigt".** Eine Lektion, die weh tat: Verschiedene Listen benutzen verschiedene Namen für den Abschluss-Status — mal „complete", mal „Closed", mal „resolved". Man kann nicht hart auf einen Namen prüfen. Jede Automatisierung fragt pro Liste ab, welcher Status als „geschlossen" gilt. Solche Kleinigkeiten trennen ein Demo-System von einem, das drei Jahre lang läuft.
+
+Der Vorteil: Alles ist für Menschen einsehbar. Wenn ein Agent etwas tut, steht es als Kommentar oder Statuswechsel im Ticket — nicht in einem Log, das niemand liest.
+
+## Ebene B: der Team-Chat als Interaktionsebene
+
+Die zweite Ebene ist Microsoft Teams — der Chat, in dem das Team ohnehin kommuniziert. Hier trifft Autonomie auf den Menschen.
+
+Der Chat ist gleich vierfach belastet:
+
+- Er ist der **einzige Auslöser** für die autonomen Bots. Kein Webhook — ein schlichter 30-Sekunden-Poll, der nach einem Triggerwort sucht. Das klingt primitiv, ist aber robust: Es gibt keine Webhook-Registrierung, die kaputtgehen kann, keine offene Schnittstelle nach außen.
+- Er ist der Kanal, auf dem Bots ihren **Status zurückmelden** — direkt im Thread, den der Mensch gerade sieht.
+- Er ist der **Agent-zu-Agent-Bus**: ein gemeinsamer Gruppenchat, in dem sich Agenten auf verschiedenen Rechnern registrieren, gegenseitig erwähnen und Fäden hinterlassen.
+- Er ist eine **Scan-Quelle** für das persönliche Cockpit.
+
+## Das schwierigste Detail: Identität
+
+Der lehrreichste Teil dieser Ebene ist die Identität — und er ist zugleich die Warnung an alle, die so etwas nachbauen.
+
+Die Bots posten über den OAuth-Token eines menschlichen Betreibers. Das heißt: In der Chat-Oberfläche teilen sich Bot und Mensch einen Anzeigenamen. Man kann sich also **niemals auf die `from.user`-Identität verlassen**, um zu erkennen, ob eine Nachricht von einem Menschen oder vom Bot kam. Die gesamte Logik muss sich stattdessen an Nachrichten-IDs festmachen: „Diese Antwort habe *ich* gepostet, jene nicht."
+
+Der Agent-zu-Agent-Bus treibt denselben Trick ins Positive: Alle Agenten posten unter *einer* technischen Dienst-Identität, aber der *logische* Absender steht im Nachrichtentext, und eine Erwähnung wie „@planer" verweist technisch auf den Menschen, der diesen Agenten hostet. Eine Identität, viele logische Agenten — und die Benachrichtigung landet trotzdem bei der richtigen Person.
+
+## Warum das die richtige Architektur ist
+
+Man könnte all das mit eigenen Services und einer Message-Queue bauen. Wir haben es bewusst nicht getan — aus drei Gründen, die für jedes Agenten-System gelten:
+
+1. **Wiederaufnehmbarkeit.** Zustand, der in einem Ticket-Kommentar lebt, überlebt jeden Neustart, jedes Deployment, jeden Absturz. Ein Agent kann jederzeit dort weitermachen, wo er aufgehört hat, weil der Zustand nicht in seinem Prozess steckt.
+
+2. **Auditierbarkeit.** Jede Koordination ist ein sichtbares Artefakt. Man muss nicht raten, warum ein Agent nachts etwas getan hat — es steht als Kommentar da, mit Zeitstempel.
+
+3. **Menschen und Maschinen sprechen dieselbe Sprache.** Ein Mensch, ein Bot und ein zeitgesteuerter Job benutzen dasselbe Vokabular: dieselben Tickets, dieselben Tags, dieselben Steuerwörter. Es gibt kein „Maschinen-Interface" neben dem „Menschen-Interface".
+
+Das ist die vielleicht wichtigste Erkenntnis aus einem Jahr Produktivbetrieb: **Koordiniere Agenten über dauerhafte, für Menschen einsehbare Artefakte — nicht über direkte Aufrufe.** Die Werkzeuge, in denen Ihr Team ohnehin arbeitet, sind oft die beste Koordinationsschicht, die Sie haben können. Man muss sie nur ernst genug nehmen, um ihre Kanten zu kennen.
+
+Im nächsten Teil steigen wir eine Ebene höher: in das Nervensystem, das auf diese Ereignisse reagiert — und in den mehrstufigen Filter, mit dem wir das Sprachmodell ehrlich halten.

--- a/beta/src/content/blog/zwei-ebenen-zustand-und-interaktion.md
+++ b/beta/src/content/blog/zwei-ebenen-zustand-und-interaktion.md
@@ -3,6 +3,7 @@ title: "Die zwei Ebenen, auf denen alles läuft: Zustand und Interaktion"
 description: "Warum ein ganzes KI-Agenten-System über zwei Standard-SaaS-Tools koordiniert statt über eigene Microservices — und was das über robuste Agenten-Architektur verrät."
 excerpt: "Das Projektmanagement-Tool ist der Speicher der Wahrheit und die Zündung. Der Team-Chat ist die Interaktions- und Transportschicht. Agenten koordinieren sich über dauerhafte Artefakte, nicht über direkte Aufrufe."
 category: "Architektur"
+image: "/images/blog/zwei-ebenen-zustand-und-interaktion.svg"
 order: 2
 date: 2026-07-12
 readingTime: "8 Min."

--- a/beta/src/lib/blog.ts
+++ b/beta/src/lib/blog.ts
@@ -1,15 +1,33 @@
 import { getCollection, type CollectionEntry } from 'astro:content';
 
 /**
- * A blog article is visible when it is published, OR whenever we are running
- * the dev server. This keeps drafted articles (`published: false`) fully
- * browsable locally while keeping them out of the production build.
+ * Magic preview key. Append `?preview=<key>` to any /blog URL in production to
+ * reveal drafted articles for the rest of the browser session. Override at
+ * build time with the PUBLIC_PREVIEW_KEY env var.
+ */
+export const PREVIEW_KEY = import.meta.env.PUBLIC_PREVIEW_KEY || 'feldnotizen-vorschau';
+
+const byOrder = (a: CollectionEntry<'blog'>, b: CollectionEntry<'blog'>) =>
+  a.data.order - b.data.order;
+
+/**
+ * A blog article is publicly visible when it is published, OR whenever we are
+ * running the dev server. Drafts (`published: false`) stay out of the public
+ * listing/teaser in production but remain browsable in dev.
  */
 export const isBlogVisible = ({ data }: CollectionEntry<'blog'>) =>
   data.published || import.meta.env.DEV;
 
-/** Visible blog posts, ordered by their series `order`. */
+/** Publicly visible blog posts, ordered by series `order`. */
 export async function getBlogPosts(): Promise<CollectionEntry<'blog'>[]> {
-  const posts = await getCollection('blog', isBlogVisible);
-  return posts.sort((a, b) => a.data.order - b.data.order);
+  return (await getCollection('blog', isBlogVisible)).sort(byOrder);
+}
+
+/**
+ * Every blog post, drafts included, ordered by series `order`. Used to build
+ * the (unlisted, gated) draft pages in production so the magic preview link
+ * has a real URL to resolve.
+ */
+export async function getAllBlogPosts(): Promise<CollectionEntry<'blog'>[]> {
+  return (await getCollection('blog')).sort(byOrder);
 }

--- a/beta/src/lib/blog.ts
+++ b/beta/src/lib/blog.ts
@@ -1,0 +1,15 @@
+import { getCollection, type CollectionEntry } from 'astro:content';
+
+/**
+ * A blog article is visible when it is published, OR whenever we are running
+ * the dev server. This keeps drafted articles (`published: false`) fully
+ * browsable locally while keeping them out of the production build.
+ */
+export const isBlogVisible = ({ data }: CollectionEntry<'blog'>) =>
+  data.published || import.meta.env.DEV;
+
+/** Visible blog posts, ordered by their series `order`. */
+export async function getBlogPosts(): Promise<CollectionEntry<'blog'>[]> {
+  const posts = await getCollection('blog', isBlogVisible);
+  return posts.sort((a, b) => a.data.order - b.data.order);
+}

--- a/beta/src/lib/blog.ts
+++ b/beta/src/lib/blog.ts
@@ -5,7 +5,7 @@ import { getCollection, type CollectionEntry } from 'astro:content';
  * reveal drafted articles for the rest of the browser session. Override at
  * build time with the PUBLIC_PREVIEW_KEY env var.
  */
-export const PREVIEW_KEY = import.meta.env.PUBLIC_PREVIEW_KEY || 'feldnotizen-vorschau';
+export const PREVIEW_KEY = import.meta.env.PUBLIC_PREVIEW_KEY || 'bumble-field-notes';
 
 const byOrder = (a: CollectionEntry<'blog'>, b: CollectionEntry<'blog'>) =>
   a.data.order - b.data.order;

--- a/beta/src/lib/footerContent.ts
+++ b/beta/src/lib/footerContent.ts
@@ -45,7 +45,7 @@ const servicesHref = lang === 'DE' ? '/services' : '/en/services';
           title: 'Lernen',
           items: [
             { label: 'FaST-Training', href: servicesHref },
-            { label: 'GPT-Training', href: servicesHref },
+            { label: 'Field Notes (KI-Serie)', href: '/blog' },
             { label: 'AI-Literacy', href: servicesHref },
             { label: 'Open Space Checkliste', href: servicesHref },
           ],
@@ -69,7 +69,7 @@ const servicesHref = lang === 'DE' ? '/services' : '/en/services';
           title: 'Learn',
           items: [
             { label: 'FaST Training', href: servicesHref },
-            { label: 'GPT Training', href: servicesHref },
+            { label: 'Field Notes (AI series)', href: '/blog' },
             { label: 'AI Literacy', href: servicesHref },
             { label: 'Open Space Checklist', href: servicesHref },
           ],

--- a/beta/src/pages/ai-consulting.astro
+++ b/beta/src/pages/ai-consulting.astro
@@ -4,6 +4,7 @@ import Nav from '../components/Nav.astro';
 import Quote from '../components/Quote.astro';
 import CTAStrip from '../components/CTAStrip.astro';
 import PipelineFlow from '../components/PipelineFlow.astro';
+import FieldNotesTeaser from '../components/FieldNotesTeaser.astro';
 import Footer from '../components/Footer.astro';
 import { getCollection } from 'astro:content';
 
@@ -112,6 +113,8 @@ let lang: 'DE' | 'EN' = 'DE';
       />
     </div>
   </section>
+
+  <FieldNotesTeaser lang={lang} />
 
   <div data-de-cta={JSON.stringify({heading: deContent.ctaHeading, headingEm: deContent.ctaHeading_em, body: deContent.ctaBody, ctaText: deContent.ctaText})} data-en-cta={JSON.stringify({heading: enContent.ctaHeading, headingEm: enContent.ctaHeading_em, body: enContent.ctaBody, ctaText: enContent.ctaText})} class="bf-cta-container">
     <CTAStrip

--- a/beta/src/pages/blog.astro
+++ b/beta/src/pages/blog.astro
@@ -1,0 +1,117 @@
+---
+import Layout from '../components/Layout.astro';
+import Nav from '../components/Nav.astro';
+import BlogList from '../components/BlogList.astro';
+import Footer from '../components/Footer.astro';
+import LangToggle from '../components/LangToggle.astro';
+---
+
+<Layout
+  title="Field Notes — Wie wir KI-Agenten in Produktion bringen | bumbleflies"
+  description="Eine Artikelserie über ein echtes KI-Agenten-Betriebssystem in Produktion: autonome Claude-Code-Bots, Event-Automatisierung mit n8n, ein Skill-Marktplatz für Firmenwissen. Keine Folien — gebaute Software."
+  canonical="https://bumbleflies.de/blog"
+  lang="DE"
+  dePath="/blog"
+>
+  <Nav slot="nav">
+    <LangToggle slot="lang" />
+  </Nav>
+
+  <section class="a-blog-hero">
+    <div class="bf-container">
+      <span class="a-blog-hero__kicker">Field Notes · KI-Serie</span>
+      <h1 class="a-blog-hero__heading">Wie wir KI-Agenten in Produktion bringen</h1>
+      <p class="a-blog-hero__subheading">
+        Kein Hype, kein Proof-of-Concept, der in der Schublade verschwindet. Eine Serie darüber,
+        wie wir für ein deutsches Legal-Tech-Unternehmen ein komplettes KI-Agenten-Betriebssystem
+        gebaut haben — autonome Bots, die Pull-Requests öffnen, während das Team schläft. Die
+        Geschichte, die Architektur und die Narben.
+      </p>
+    </div>
+  </section>
+
+  <BlogList />
+
+  <section class="a-blog-cta">
+    <div class="bf-container">
+      <h2>Sie haben die romantische Vorstellung, dass wir da einen Schatz haben?</h2>
+      <p>Haben wir. Schreiben Sie uns zwei Sätze zu Ihrem Thema — wir antworten mit einer ehrlichen Einschätzung.</p>
+      <a href="mailto:info@bumbleflies.de" class="bf-cta">Erstes Gespräch vereinbaren</a>
+    </div>
+  </section>
+
+  <Footer slot="footer" />
+</Layout>
+
+<style>
+  .a-blog-hero {
+    padding: var(--space-4xl) 0 var(--space-2xl);
+    background: var(--paper);
+  }
+
+  .a-blog-hero__kicker {
+    display: inline-block;
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    text-transform: uppercase;
+    letter-spacing: var(--ls-widest);
+    color: var(--accent);
+    margin-bottom: var(--space-md);
+  }
+
+  .a-blog-hero__heading {
+    font-family: var(--font-display);
+    font-size: var(--text-6xl);
+    line-height: var(--lh-tight);
+    margin: 0 0 1rem 0;
+    color: var(--ink);
+    max-width: 900px;
+  }
+
+  .a-blog-hero__subheading {
+    font-size: var(--text-lg);
+    color: var(--ink-soft);
+    max-width: 720px;
+    margin: 0;
+    line-height: var(--lh-body);
+  }
+
+  .a-blog-cta {
+    padding: var(--space-4xl) 0;
+    text-align: center;
+    background: var(--paper);
+    border-top: 1px solid var(--rule);
+  }
+
+  .a-blog-cta h2 {
+    font-family: var(--font-display);
+    font-size: var(--text-3xl);
+    margin: 0 auto 1rem;
+    max-width: 720px;
+    color: var(--ink);
+  }
+
+  .a-blog-cta p {
+    color: var(--ink-soft);
+    max-width: 560px;
+    margin: 0 auto 2rem;
+  }
+
+  @media (max-width: 768px) {
+    .a-blog-hero {
+      padding: var(--space-2xl) 0 var(--space-xl);
+    }
+
+    .a-blog-hero__heading {
+      font-size: var(--text-3xl);
+    }
+
+    .a-blog-hero__subheading {
+      font-size: 1rem;
+    }
+
+    .a-blog-cta h2 {
+      font-size: var(--text-xl);
+    }
+  }
+</style>

--- a/beta/src/pages/blog/[slug].astro
+++ b/beta/src/pages/blog/[slug].astro
@@ -1,0 +1,340 @@
+---
+import { getCollection, render } from 'astro:content';
+import Layout from '../../components/Layout.astro';
+import Nav from '../../components/Nav.astro';
+import Footer from '../../components/Footer.astro';
+import LangToggle from '../../components/LangToggle.astro';
+
+export async function getStaticPaths() {
+  const posts = await getCollection('blog', ({ data }) => data.published);
+  const ordered = [...posts].sort((a, b) => a.data.order - b.data.order);
+  return ordered.map((post, i) => ({
+    params: { slug: post.id },
+    props: {
+      post,
+      prev: ordered[i - 1] ?? null,
+      next: ordered[i + 1] ?? null,
+    },
+  }));
+}
+
+const { post, prev, next } = Astro.props;
+const { Content } = await render(post);
+const dateLabel = post.data.date.toLocaleDateString('de-DE', {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+});
+---
+
+<Layout
+  title={`${post.data.title} | bumbleflies`}
+  description={post.data.description}
+  canonical={`https://bumbleflies.de/blog/${post.id}`}
+  lang="DE"
+  dePath={`/blog/${post.id}`}
+>
+  <Nav slot="nav">
+    <LangToggle slot="lang" />
+  </Nav>
+
+  <article class="post">
+    <main class="post__page">
+      <a href="/blog" class="post__breadcrumb">← Alle Artikel</a>
+
+      <header class="post__header">
+        <div class="post__meta">
+          <span class="post__part">Teil {String(post.data.order).padStart(2, '0')}</span>
+          <span class="post__category">{post.data.category}</span>
+        </div>
+        <h1 class="post__title">{post.data.title}</h1>
+        <p class="post__lead">{post.data.description}</p>
+        <div class="post__byline">
+          <span>{post.data.author}</span>
+          <span aria-hidden="true">·</span>
+          <time datetime={post.data.date.toISOString()}>{dateLabel}</time>
+          {post.data.readingTime && (
+            <>
+              <span aria-hidden="true">·</span>
+              <span>{post.data.readingTime}</span>
+            </>
+          )}
+        </div>
+      </header>
+
+      <div class="post__content">
+        <Content />
+      </div>
+
+      <nav class="post__pager">
+        {prev ? (
+          <a href={`/blog/${prev.id}`} class="post__pager-link post__pager-link--prev">
+            <span class="post__pager-dir">← Vorheriger Teil</span>
+            <span class="post__pager-title">{prev.data.title}</span>
+          </a>
+        ) : <span />}
+        {next ? (
+          <a href={`/blog/${next.id}`} class="post__pager-link post__pager-link--next">
+            <span class="post__pager-dir">Nächster Teil →</span>
+            <span class="post__pager-title">{next.data.title}</span>
+          </a>
+        ) : <span />}
+      </nav>
+
+      <aside class="post__cta">
+        <p>Klingt nach einem Thema, das Sie auch bewegt?</p>
+        <a href="mailto:info@bumbleflies.de" class="post__button">Erstes Gespräch buchen</a>
+      </aside>
+    </main>
+  </article>
+
+  <Footer slot="footer" />
+</Layout>
+
+<style>
+  .post__page {
+    max-width: 760px;
+    margin: 0 auto;
+    padding: 0 var(--space-3xl);
+  }
+
+  @media (max-width: 768px) {
+    .post__page {
+      padding: 0 var(--space-lg);
+    }
+  }
+
+  .post__breadcrumb {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 30px;
+    margin-bottom: var(--space-xl);
+    color: var(--accent);
+    text-decoration: none;
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    text-transform: uppercase;
+    letter-spacing: var(--ls-widest);
+    transition: opacity var(--duration-fast) var(--easing-default);
+  }
+
+  .post__breadcrumb:hover {
+    opacity: 0.7;
+  }
+
+  .post__header {
+    margin-bottom: var(--space-3xl);
+    padding-bottom: var(--space-xl);
+    border-bottom: 1px solid var(--rule);
+  }
+
+  .post__meta {
+    display: flex;
+    gap: var(--space-sm);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    text-transform: uppercase;
+    letter-spacing: var(--ls-wider);
+    margin-bottom: var(--space-md);
+  }
+
+  .post__part { color: var(--accent); }
+  .post__category { color: var(--ink-soft); }
+
+  .post__title {
+    font-family: var(--font-display);
+    font-size: var(--text-5xl);
+    line-height: var(--lh-tight);
+    margin: 0 0 var(--space-lg);
+    color: var(--ink);
+  }
+
+  .post__lead {
+    font-size: var(--text-lg);
+    line-height: var(--lh-body);
+    color: var(--ink-soft);
+    margin: 0 0 var(--space-lg);
+  }
+
+  .post__byline {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-sm);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--ink-soft);
+  }
+
+  /* Article body */
+  .post__content {
+    margin-bottom: var(--space-4xl);
+    font-size: var(--text-lg);
+    line-height: var(--lh-loose);
+    color: var(--ink);
+  }
+
+  .post__content :global(h2) {
+    font-family: var(--font-display);
+    font-size: var(--text-3xl);
+    line-height: var(--lh-snug);
+    margin: var(--space-3xl) 0 var(--space-md);
+    color: var(--ink);
+  }
+
+  .post__content :global(h3) {
+    font-family: var(--font-display);
+    font-size: var(--text-xl);
+    margin: var(--space-2xl) 0 var(--space-sm);
+    color: var(--ink);
+  }
+
+  .post__content :global(p) {
+    margin: 0 0 var(--space-lg);
+  }
+
+  .post__content :global(a) {
+    color: var(--accent);
+    text-decoration: underline;
+    text-underline-offset: 3px;
+  }
+
+  .post__content :global(strong) {
+    color: var(--ink);
+    font-weight: 600;
+  }
+
+  .post__content :global(em) { font-style: italic; }
+
+  .post__content :global(ul),
+  .post__content :global(ol) {
+    margin: var(--space-lg) 0;
+    padding-left: var(--space-xl);
+  }
+
+  .post__content :global(li) {
+    margin-bottom: var(--space-sm);
+  }
+
+  .post__content :global(blockquote) {
+    margin: var(--space-2xl) 0;
+    padding: var(--space-lg) var(--space-xl);
+    border-left: 4px solid var(--accent);
+    background: var(--paper);
+    font-family: var(--font-display);
+    font-style: italic;
+    font-size: var(--text-xl);
+    line-height: var(--lh-loose);
+    color: var(--ink);
+  }
+
+  .post__content :global(blockquote p) { margin: 0; }
+
+  .post__content :global(code) {
+    font-family: var(--font-mono);
+    font-size: 0.9em;
+    background: var(--paper);
+    padding: 0.15em 0.4em;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--rule);
+  }
+
+  .post__content :global(pre) {
+    background: var(--paper);
+    border: 1px solid var(--rule);
+    border-radius: var(--radius-sm);
+    padding: var(--space-lg);
+    overflow-x: auto;
+    margin: var(--space-lg) 0;
+  }
+
+  .post__content :global(pre code) {
+    background: none;
+    border: none;
+    padding: 0;
+  }
+
+  .post__content :global(hr) {
+    border: none;
+    border-top: 1px solid var(--rule);
+    margin: var(--space-3xl) 0;
+  }
+
+  /* Prev/next pager */
+  .post__pager {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--space-lg);
+    margin: var(--space-3xl) 0;
+    padding-top: var(--space-xl);
+    border-top: 1px solid var(--rule);
+  }
+
+  .post__pager-link {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    text-decoration: none;
+    padding: var(--space-lg);
+    border: 1px solid var(--rule);
+    border-radius: var(--radius-sm);
+    transition: border-color var(--duration-fast) var(--easing-default);
+  }
+
+  .post__pager-link:hover { border-color: var(--accent); }
+  .post__pager-link--next { text-align: right; }
+
+  .post__pager-dir {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    text-transform: uppercase;
+    letter-spacing: var(--ls-wider);
+    color: var(--accent);
+  }
+
+  .post__pager-title {
+    color: var(--ink);
+    font-size: var(--text-sm);
+  }
+
+  /* CTA */
+  .post__cta {
+    text-align: center;
+    margin: var(--space-4xl) 0;
+    padding: var(--space-2xl);
+    background: var(--paper);
+    border-radius: var(--radius-sm);
+  }
+
+  .post__cta p {
+    color: var(--ink);
+    margin: 0 0 var(--space-lg);
+    font-family: var(--font-display);
+    font-size: var(--text-xl);
+  }
+
+  .post__button {
+    display: inline-block;
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    letter-spacing: var(--ls-wider);
+    color: var(--bg);
+    background: var(--ink);
+    text-decoration: none;
+    padding: var(--space-md) var(--space-lg);
+    border-radius: var(--radius-full);
+    transition: transform var(--duration-fast) var(--easing-default), background var(--duration-fast) var(--easing-default);
+  }
+
+  .post__button:hover {
+    transform: translateY(-2px);
+    background: var(--accent);
+  }
+
+  @media (max-width: 768px) {
+    .post__title { font-size: var(--text-3xl); }
+    .post__content { font-size: 1rem; }
+    .post__pager { grid-template-columns: 1fr; }
+    .post__pager-link--next { text-align: left; }
+  }
+</style>

--- a/beta/src/pages/blog/[slug].astro
+++ b/beta/src/pages/blog/[slug].astro
@@ -1,14 +1,17 @@
 ---
 import { render } from 'astro:content';
-import { getBlogPosts } from '../../lib/blog';
+import { getAllBlogPosts } from '../../lib/blog';
 import Layout from '../../components/Layout.astro';
 import Nav from '../../components/Nav.astro';
 import Footer from '../../components/Footer.astro';
 import LangToggle from '../../components/LangToggle.astro';
 import BlogCover from '../../components/BlogCover.astro';
 
+// Build every article — drafts included — so the magic preview link resolves in
+// production. Drafts are noindex'd and gated client-side (see the .post__locked
+// notice + [data-preview] cascade below).
 export async function getStaticPaths() {
-  const ordered = await getBlogPosts();
+  const ordered = await getAllBlogPosts();
   return ordered.map((post, i) => ({
     params: { slug: post.id },
     props: {
@@ -20,6 +23,7 @@ export async function getStaticPaths() {
 }
 
 const { post, prev, next } = Astro.props;
+const isDraft = !post.data.published;
 const { Content } = await render(post);
 const dateLabel = post.data.date.toLocaleDateString('de-DE', {
   year: 'numeric',
@@ -34,14 +38,29 @@ const dateLabel = post.data.date.toLocaleDateString('de-DE', {
   canonical={`https://bumbleflies.de/blog/${post.id}`}
   lang="DE"
   dePath={`/blog/${post.id}`}
+  noindex={isDraft}
 >
   <Nav slot="nav">
     <LangToggle slot="lang" />
   </Nav>
 
-  <article class="post">
+  <article class="post" data-draft={isDraft ? '' : undefined}>
+    {isDraft && (
+      <div class="post__locked">
+        <div class="bf-container post__locked-inner">
+          <span class="post__locked-tag">Entwurf</span>
+          <h1 class="post__locked-title">Dieser Artikel ist noch nicht veröffentlicht.</h1>
+          <p class="post__locked-text">
+            Er gehört zur Vorschau der Field-Notes-Serie. Öffne die Serie mit deinem
+            Vorschau-Link, um ihn zu lesen.
+          </p>
+          <a href="/blog" class="post__locked-link">← Zur Übersicht</a>
+        </div>
+      </div>
+    )}
     <main class="post__page">
       <a href="/blog" class="post__breadcrumb">← Alle Artikel</a>
+      {isDraft && <span class="post__preview-tag">Vorschau</span>}
 
       <header class="post__header">
         <div class="post__meta">
@@ -99,6 +118,64 @@ const dateLabel = post.data.date.toLocaleDateString('de-DE', {
 </Layout>
 
 <style>
+  /* Draft gating — the article body shows only when the magic preview key has
+     set [data-preview="on"] on <html> (see Layout's inline script). */
+  .post__locked { display: none; }
+  .post[data-draft] .post__locked { display: block; padding: var(--space-4xl) 0; }
+  :global(html[data-preview='on']) .post[data-draft] .post__locked { display: none; }
+
+  .post[data-draft] .post__page { display: none; }
+  :global(html[data-preview='on']) .post[data-draft] .post__page { display: block; }
+
+  .post__locked-inner { max-width: 760px; }
+
+  .post__locked-tag {
+    display: inline-block;
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    text-transform: uppercase;
+    letter-spacing: var(--ls-widest);
+    color: var(--accent);
+    margin-bottom: var(--space-md);
+  }
+
+  .post__locked-title {
+    font-family: var(--font-display);
+    font-size: var(--text-4xl);
+    line-height: var(--lh-tight);
+    color: var(--ink);
+    margin: 0 0 var(--space-md);
+  }
+
+  .post__locked-text {
+    font-size: var(--text-lg);
+    color: var(--ink-soft);
+    line-height: var(--lh-body);
+    max-width: 560px;
+    margin: 0 0 var(--space-lg);
+  }
+
+  .post__locked-link {
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    letter-spacing: var(--ls-wide);
+    color: var(--accent);
+    text-decoration: none;
+  }
+
+  .post__preview-tag {
+    display: inline-block;
+    margin-left: var(--space-md);
+    padding: 2px 10px;
+    border: 1px solid var(--accent);
+    border-radius: var(--radius-full);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    text-transform: uppercase;
+    letter-spacing: var(--ls-wide);
+    color: var(--accent);
+  }
+
   .post__page {
     max-width: 760px;
     margin: 0 auto;

--- a/beta/src/pages/blog/[slug].astro
+++ b/beta/src/pages/blog/[slug].astro
@@ -1,13 +1,14 @@
 ---
-import { getCollection, render } from 'astro:content';
+import { render } from 'astro:content';
+import { getBlogPosts } from '../../lib/blog';
 import Layout from '../../components/Layout.astro';
 import Nav from '../../components/Nav.astro';
 import Footer from '../../components/Footer.astro';
 import LangToggle from '../../components/LangToggle.astro';
+import BlogCover from '../../components/BlogCover.astro';
 
 export async function getStaticPaths() {
-  const posts = await getCollection('blog', ({ data }) => data.published);
-  const ordered = [...posts].sort((a, b) => a.data.order - b.data.order);
+  const ordered = await getBlogPosts();
   return ordered.map((post, i) => ({
     params: { slug: post.id },
     props: {
@@ -61,6 +62,12 @@ const dateLabel = post.data.date.toLocaleDateString('de-DE', {
           )}
         </div>
       </header>
+
+      {post.data.image && (
+        <figure class="post__cover">
+          <BlogCover image={post.data.image} />
+        </figure>
+      )}
 
       <div class="post__content">
         <Content />
@@ -164,6 +171,13 @@ const dateLabel = post.data.date.toLocaleDateString('de-DE', {
     font-family: var(--font-mono);
     font-size: var(--text-xs);
     color: var(--ink-soft);
+  }
+
+  .post__cover {
+    margin: 0 0 var(--space-3xl);
+    border: 1px solid var(--rule);
+    border-radius: var(--radius-sm);
+    overflow: hidden;
   }
 
   /* Article body */

--- a/beta/src/pages/en/ai-consulting.astro
+++ b/beta/src/pages/en/ai-consulting.astro
@@ -4,6 +4,7 @@ import Nav from '../../components/Nav.astro';
 import Quote from '../../components/Quote.astro';
 import CTAStrip from '../../components/CTAStrip.astro';
 import PipelineFlow from '../../components/PipelineFlow.astro';
+import FieldNotesTeaser from '../../components/FieldNotesTeaser.astro';
 import Footer from '../../components/Footer.astro';
 import { getCollection } from 'astro:content';
 
@@ -88,6 +89,8 @@ const lang: 'DE' | 'EN' = 'EN';
       />
     </div>
   </section>
+
+  <FieldNotesTeaser lang={lang} />
 
   <CTAStrip
     heading={content.ctaHeading}

--- a/history/2026-07-10_ai-consulting-blog-series.md
+++ b/history/2026-07-10_ai-consulting-blog-series.md
@@ -1,0 +1,99 @@
+# AI-Consulting Blog Series — "Field Notes" (2026-07-10)
+
+Anonymized, production-ready blog series that turns our real KI-agent operating
+system into proof-of-work marketing for the AI-consulting offering. Everything is
+integrated into the site and ships **dark** — each article has its own live switch
+so you can flip them on one at a time as you align promotion.
+
+---
+
+## What was built
+
+- A new `blog` **content collection** (`beta/src/content.config.ts`) with a
+  `published` boolean per article — the per-article live switch.
+- **6 articles** (German, anonymized) under `beta/src/content/blog/`.
+- A **listing page** `/blog` (`beta/src/pages/blog.astro`) + **article pages**
+  `/blog/<slug>` (`beta/src/pages/blog/[slug].astro`) with prev/next series pager.
+- Components `BlogList.astro` + `BlogCard.astro` (mirror the case-studies design).
+- A **gated nav link** ("Field Notes") in `Nav.astro` that only appears once at
+  least one article is live.
+
+## How the live switch works
+
+Each article's frontmatter carries:
+
+```yaml
+published: false   # ← the switch. false = drafted & dark, true = live
+```
+
+- `false` — the article is **not built** into a page and **not listed**. Invisible.
+- `true`  — the article page builds at `/blog/<slug>`, appears in the `/blog`
+  listing, and the "Field Notes" nav link turns on across the whole site.
+
+**Nothing is visible until you flip a switch** — merging this PR to `master`
+changes nothing a visitor can see. The `/blog` index exists but is unlinked and
+shows a "coming soon" line until the first article goes live.
+
+### To publish an article
+
+1. Open the article file (see table below) and set `published: true`.
+2. Commit + push to `master`. The GitHub Actions build (`build-www.yml`) rebuilds
+   the Docker image and deploys. The article, the listing entry, and the nav link
+   appear together.
+
+To take one back down, set it to `false` again and push. That's the whole flow —
+no code changes, no separate CMS.
+
+> Tip for a coordinated launch: flip **Teil 01 (Überblick)** live first (it teases
+> the whole series and links onward), then release Teil 02–06 on whatever cadence
+> your promotion plan wants. The prev/next pager only links between *published*
+> articles, so a partially-released series stays coherent.
+
+## The 6 articles (series order)
+
+| # | Slug (`beta/src/content/blog/…`) | Titel | Thema |
+|---|---|---|---|
+| 01 | `ki-agenten-betriebssystem.md` | Ein KI-Agenten-Betriebssystem für ein Legal-Tech-Unternehmen | Überblick |
+| 02 | `zwei-ebenen-zustand-und-interaktion.md` | Die zwei Ebenen, auf denen alles läuft | Architektur |
+| 03 | `nervensystem-n8n-automatisierung.md` | Das Nervensystem: Event-Automatisierung | Automatisierung |
+| 04 | `skills-als-apps-plugin-marktplatz.md` | Skills als Apps: ein Plugin-Marktplatz | Plattform |
+| 05 | `bots-die-nachts-arbeiten.md` | Bots, die arbeiten, während du schläfst | Autonomie |
+| 06 | `cockpit-tag-mit-zehn-agenten.md` | Ein Cockpit für einen Menschen | Produktivität |
+
+Series order is controlled by the `order:` field, not the filename or date.
+
+## Anonymization (important)
+
+The articles are derived from an internal research dossier about a real system.
+Before writing, all identifying material was stripped:
+
+- **No client/company name** → "ein deutsches Legal-Tech-Unternehmen".
+- **No people, handles, emails, internal IDs, keys, hostnames, product names.**
+- Generic tool names are **kept on purpose** (Claude Code, n8n, ClickUp, Microsoft
+  Teams, Azure) — common, non-identifying, and good for SEO.
+- The framing is first-person ("wir haben gebaut") as the practitioners who built
+  it — no invented consulting-client contract is claimed.
+
+A `grep` guard was run to confirm no identifiers leaked. **If you edit or add
+articles, re-run an anonymization pass** before publishing.
+
+## Open follow-ups (not in this PR)
+
+- **English versions** — the series is DE-only (matches the site default and the
+  ai-consulting page). EN variants under `beta/src/pages/en/blog/` are a clean
+  follow-up if the market calls for it.
+- **Consent** — confirm with the source company how it may be referenced, even
+  anonymized, before broad promotion.
+- **Cross-linking** — optionally add a "Field Notes" teaser block to the
+  `/ai-consulting` page once the first article is live.
+- **OG/social images** per article for LinkedIn promotion.
+
+## Verification done
+
+- `npm run build` green — 28 pages. With all articles draft, only `/blog/`
+  (empty state) builds; no article pages, no nav link.
+- Flip-test: set one article `published: true` → its `/blog/<slug>/` page builds
+  **and** the "Field Notes" nav link renders; reverted to `false` afterward.
+- Anonymization `grep` guard: clean.
+- (`astro check` currently errors from an unrelated language-server/tsconfig issue
+  in this environment; the production build is the authoritative type/schema gate.)


### PR DESCRIPTION
## What this is

A production-ready, **anonymized** German blog series that turns our real KI-agent operating system into proof-of-work marketing for the AI-consulting offering. It directly answers the customer quote already on `/ai-consulting` — *"…dann laufen Agents los, implementieren das, machen Pull-Requests? Ich habe die romantische Vorstellung, dass ihr da einen Schatz habt."* This is that Schatz, written up.

Everything is integrated and **ships dark** — nothing is visible until you flip a switch.

## The individual live switch

Each article's frontmatter has `published: false`. Set it to `true` + push to `master`:
- the article page builds at `/blog/<slug>`,
- it appears in the `/blog` listing,
- the **"Field Notes" nav link** turns on site-wide.

With all articles draft (the state in this PR), only the empty `/blog` index builds and the nav link stays hidden — so merging this changes nothing a visitor sees. Flip them one at a time to align with your promotion plan.

## The 6 articles (all draft)

| # | Slug | Titel |
|---|------|-------|
| 01 | `ki-agenten-betriebssystem` | Ein KI-Agenten-Betriebssystem für ein Legal-Tech-Unternehmen |
| 02 | `zwei-ebenen-zustand-und-interaktion` | Die zwei Ebenen, auf denen alles läuft |
| 03 | `nervensystem-n8n-automatisierung` | Das Nervensystem: Event-Automatisierung |
| 04 | `skills-als-apps-plugin-marktplatz` | Skills als Apps: ein Plugin-Marktplatz |
| 05 | `bots-die-nachts-arbeiten` | Bots, die arbeiten, während du schläfst |
| 06 | `cockpit-tag-mit-zehn-agenten` | Ein Cockpit für einen Menschen |

## What's included

- `blog` content collection + schema (`published` = the switch)
- 6 anonymized articles, `/blog` listing + `/blog/<slug>` pages with series prev/next pager
- `BlogList` + `BlogCard` components (case-studies design system)
- Gated "Field Notes" nav link
- Publishing guide: `history/2026-07-10_ai-consulting-blog-series.md`

## Anonymization

No client name (→ "ein deutsches Legal-Tech-Unternehmen"), no people/handles/emails/internal IDs/keys/hostnames/product names. Generic tool names kept on purpose (Claude Code, n8n, ClickUp, Teams, Azure) for SEO. A `grep` guard confirmed no identifiers leaked. **Please still get source-company sign-off before broad promotion.**

## Verification

- `npm run build` green (28 pages). All-draft → only `/blog` index builds; flip-test → article page + nav link appear, then reverted.

## Follow-ups (not in this PR)

- English variants (`/en/blog/`) — series is DE-only for now
- Optional "Field Notes" teaser on `/ai-consulting`
- Per-article OG/social images for LinkedIn

🤖 Generated with [Claude Code](https://claude.com/claude-code)