### PR TITLE
fix: eliminate horizontal-scrollbar overflow in nav and hero packages

### DIFF
--- a/beta/src/components/Hero.astro
+++ b/beta/src/components/Hero.astro
@@ -229,7 +229,7 @@ const content = lang === 'DE'
   .a-hero__engagement-packages {
     margin-top: var(--space-3xl);
     display: grid;
-    grid-template-columns: repeat(4, 1fr);
+    grid-template-columns: repeat(4, minmax(0, 1fr));
     gap: var(--space-4xl);
     padding-top: var(--space-xl);
     padding-bottom: var(--space-xl);
@@ -326,7 +326,7 @@ const content = lang === 'DE'
     }
 
     .a-hero__engagement-packages {
-      grid-template-columns: repeat(2, 1fr);
+      grid-template-columns: repeat(2, minmax(0, 1fr));
       gap: var(--space-2xl);
     }
 
@@ -343,7 +343,7 @@ const content = lang === 'DE'
 
   @media (max-width: 480px) {
     .a-hero__engagement-packages {
-      grid-template-columns: 1fr;
+      grid-template-columns: minmax(0, 1fr);
       gap: var(--space-2xl);
       text-align: center;
     }

--- a/beta/src/components/Nav.astro
+++ b/beta/src/components/Nav.astro
@@ -14,13 +14,11 @@ const { lang = 'DE', cta, ctaHref = 'mailto:info@bumbleflies.de' } = Astro.props
 const navItems = lang === 'DE'
   ? [
       { label: 'Facilitation · AI · Software', href: '/services' },
-      { label: 'AI Consulting', href: '/ai-consulting' },
       { label: 'remote, hybrid & vor Ort', href: '/how-we-work' },
       { label: 'Warum · Wir', href: '/why-we' },
     ]
   : [
       { label: 'Facilitation · AI · Software', href: '/en/services' },
-      { label: 'AI Consulting', href: '/en/ai-consulting' },
       { label: 'remote, hybrid & on-site', href: '/en/how-we-work' },
       { label: 'Why · We', href: '/en/why-we' },
     ];
@@ -120,6 +118,19 @@ const ctaLabel = cta || (lang === 'DE' ? 'Schreib uns' : 'Get in touch');
     flex-shrink: 0;
   }
 
+  /*
+   * .bf-nav__links uses white-space: nowrap so its min-content width equals
+   * its full rendered width — flex-shrink can't reduce it below that. Once
+   * brand + links + right no longer fit on one nowrap row, the row overflows
+   * the viewport instead of shrinking, so links must hide before that point
+   * rather than at the generic mobile breakpoint alone.
+   */
+  @media (max-width: 1300px) {
+    .bf-nav__links {
+      display: none;
+    }
+  }
+
   @media (max-width: 768px) {
     .bf-nav {
       padding: 16px 0;
@@ -130,10 +141,6 @@ const ctaLabel = cta || (lang === 'DE' ? 'Schreib uns' : 'Get in touch');
       gap: var(--space-lg);
       flex-wrap: wrap;
       justify-content: flex-start;
-    }
-
-    .bf-nav__links {
-      display: none;
     }
   }
 </style>

--- a/beta/tests/Nav.test.ts
+++ b/beta/tests/Nav.test.ts
@@ -5,13 +5,12 @@ describe('Nav Component Logic', () => {
     const lang = 'DE';
     const navItems = [
       { label: 'Facilitation · AI · Software', href: '/services' },
-      { label: 'AI Consulting', href: '/ai-consulting' },
       { label: 'remote, hybrid & vor Ort', href: '/how-we-work' },
       { label: 'Warum · Wir', href: '/why-we' },
     ];
-    
+
     expect(lang).toBe('DE');
-    expect(navItems.length).toBe(4);
+    expect(navItems.length).toBe(3);
     expect(navItems[0].href).toBe('/services');
   });
 
@@ -19,13 +18,12 @@ describe('Nav Component Logic', () => {
     const lang = 'EN';
     const navItems = [
       { label: 'Facilitation · AI · Software', href: '/en/services' },
-      { label: 'AI Consulting', href: '/en/ai-consulting' },
       { label: 'remote, hybrid & on-site', href: '/en/how-we-work' },
       { label: 'Why · We', href: '/en/why-we' },
     ];
-    
+
     expect(lang).toBe('EN');
-    expect(navItems.length).toBe(4);
+    expect(navItems.length).toBe(3);
     expect(navItems[0].href).toContain('/en/');
   });
 


### PR DESCRIPTION
## Summary
- Removed "AI Consulting" from the top navbar (still reachable via the "Entscheiden" flow section and footer), and hid the remaining nav links earlier — `max-width: 1300px` instead of the old `768px`-only cutoff — since `.bf-nav__links` uses `white-space: nowrap`, so its min-content width equals its full rendered width and can never actually shrink. Root-caused live against bumbleflies.de: the row overflowed the viewport for any window roughly 769–1600px wide.
- Fixed a separate overflow in the hero "engagement packages" row: its grid tracks used bare `1fr` (= `minmax(auto, 1fr)`), which can't shrink below content's min-content width. Switched to `minmax(0, 1fr)` across all three responsive grid variants so tracks actually shrink to fit. This was hit in a narrow band just above the 768px breakpoint, where `window.innerWidth` (used for media queries) and the scrollbar-adjusted `clientWidth` diverge.

## Test plan
- [x] `npm run test` — 40/48 pass; the 1 failing suite (`bilingual-content.integration.test.ts`, 8 tests) times out identically on unmodified `master` (verified via `git stash`), unrelated to this change
- [x] `npm run build` — succeeds
- [x] Verified live in a real browser against the dev server across 485px–1920px viewport widths: zero horizontal overflow at any width, both before/after comparison against production bumbleflies.de
- [x] Visual check of nav (3 links, CTA fits) and hero packages row (no clipped/overflowing cards) via screenshot

## Known follow-up (not in this PR)
- A pre-existing, unrelated overflow in `.a-flow-outputs` (the "Ein Pfad. Vier Stationen." section's output lists) was found during verification at ~755px viewport width. Separate root cause, not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)